### PR TITLE
feat: HTTPS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ Since the result is a single binary it is easy to start it anywhere.
 On Linux, `livesim2` can be run as a `systemd` service.
 More information can be found in the `./deployment` directory.
 
+## HTTPS and HTTP/2
+
+HTTPS and HTTP/2 are both supported. To enable TLS encryption, the two parameters
+`certpath` and `keypath` must be set to point to an HLS certificaten and a private
+key file, respectively. It is also recommended to set the port to the default HTTPS
+port 443.
+
 ## License
 
 See [LICENSE.md](LICENSE.md).

--- a/cmd/livesim2/main.go
+++ b/cmd/livesim2/main.go
@@ -63,13 +63,20 @@ func run() (exitCode int) {
 		}
 		return 1
 	}
+
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", server.Cfg.Port),
 		Handler: server.Router,
 	}
 
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		var err error
+		if cfg.CertPath != "" && cfg.KeyPath != "" { // HTTPS
+			err = srv.ListenAndServeTLS(cfg.CertPath, cfg.KeyPath)
+		} else {
+			err = srv.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
 			logger.Error().Err(err).Msg("")
 			exitCode = 1
 			startIssue <- struct{}{}


### PR DESCRIPTION
livesim2 server support for HTTPS.

To start in this mode, certpath and keypath must be configured.

Port is not automatically set to 443. That needs to be set separately.

HTTP/2 was already supported by the framework, but it will now work with TLS encryption.