### PR TITLE
New URL parameter to set stpp region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- nothing yet
+- new parameter subsstppreg can can change vertical region
 
 ## [0.5.1] - 2023-03-09
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ prepare:
 livesim2 dashfetcher:
 	go build -ldflags "-X github.com/Dash-Industry-Forum/livesim2.internal.commitVersion=$$(git describe --tags HEAD) -X github.com/Dash-Industry-Forum/livesim2.internal.commitDate=$$(git log -1 --format=%ct)" -o out/$@ ./cmd/$@/main.go
 
+forlinux: prepare
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/Dash-Industry-Forum/livesim2.internal.commitVersion=$$(git describe --tags HEAD) -X github.com/Dash-Industry-Forum/livesim2.internal.commitDate=$$(git log -1 --format=%ct)" -o out-linux/livesim2 ./cmd/livesim2/main.go
+	GOOS=linux GOARCH=amd64 go build -ldflags "-X github.com/Dash-Industry-Forum/livesim2.internal.commitVersion=$$(git describe --tags HEAD) -X github.com/Dash-Industry-Forum/livesim2.internal.commitDate=$$(git log -1 --format=%ct)" -o out-linux/dashfetcher ./cmd/dashfetcher/main.go
+
+
 .PHONY: test
 test: prepare
 	go test ./...

--- a/cmd/dashfetcher/main.go
+++ b/cmd/dashfetcher/main.go
@@ -27,7 +27,7 @@ The -a/--auto option adds output subdirectories fromn the URL removing common pr
 Some possible resources are available at https://cta-wave.github.io/Test-Content/.
 To download one of them, try
 
-$ %s -a https://cta-wave.github.io/Test-Content/https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1/2022-10-17/stream.mpd
+$ %s -a https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1/2022-10-17/stream.mpd
 `
 
 func parseOptions() *app.Options {

--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -49,6 +49,7 @@ type ResponseConfig struct {
 	AvailabilityTimeCompleteFlag bool     `json:"AvailabilityTimeCompleteFlag,omitempty"`
 	TimeSubsStpp                 []string `json:"TimeSubsStppLanguages,omitempty"`
 	TimeSubsDurMS                int      `json:"TimeSubsDurMS,omitempty"`
+	TimeSubsRegion               int      `json:"TimeSubsRegion,omitempty"`
 }
 
 // NewResponseConfig returns a new ResponseConfig with default values.
@@ -182,6 +183,8 @@ cfgLoop:
 			cfg.TimeSubsStpp = strings.Split(val, ",")
 		case "timesubsdur": // duration in milliseconds
 			cfg.TimeSubsDurMS = sc.Atoi(key, val)
+		case "timesubsreg": // retion (0 or 1)
+			cfg.TimeSubsRegion = sc.Atoi(key, val)
 		default:
 			contentStartIdx = i
 			break cfgLoop
@@ -207,6 +210,9 @@ func verifyConfig(cfg *ResponseConfig) error {
 	}
 	if len(cfg.TimeSubsStpp) > 0 && cfg.SegTimelineFlag {
 		return fmt.Errorf("combination of SegTimeline and generated stpp subtitles not yet supported")
+	}
+	if cfg.TimeSubsRegion < 0 || cfg.TimeSubsRegion > 1 {
+		return fmt.Errorf("timesubsreg number must be 0 or 1")
 	}
 	return nil
 }

--- a/cmd/livesim2/app/handler_livesim_test.go
+++ b/cmd/livesim2/app/handler_livesim_test.go
@@ -46,7 +46,7 @@ const outputPayload = `<?xml version="1.0" encoding="UTF-8"?>
     </layout>
   </head>
   <body style="s0">
-<div region="r0">
+<div region="r1">
 <p xml:id="0-0" begin="00:00:00.000" end="00:00:00.600"><span style="s1">1970-01-01T00:00:00Z<br/>en # 0</span></p>
 <p xml:id="0-1" begin="00:00:01.000" end="00:00:01.600"><span style="s1">1970-01-01T00:00:01Z<br/>en # 0</span></p>
 </div>
@@ -150,7 +150,7 @@ func TestTimeStppMediaSegment(t *testing.T) {
 		{
 			desc:               "mediasegment 0 with matching language",
 			asset:              "testpic_2s",
-			url:                "/livesim2/timesubsstpp_en,sv/timesubsdur_600/testpic_2s/timestpp-en/0.m4s?nowMS=10000",
+			url:                "/livesim2/timesubsstpp_en,sv/timesubsdur_600/timesubsreg_1/testpic_2s/timestpp-en/0.m4s?nowMS=10000",
 			segmentMimeType:    "application/mp4",
 			cues:               nil,
 			expectedStatusCode: http.StatusOK,

--- a/cmd/livesim2/app/static/urlparams.html
+++ b/cmd/livesim2/app/static/urlparams.html
@@ -21,6 +21,7 @@
         <tr><td>chunkdur</td><td>float</td><td>Chunk duration for on-the-fly chunking</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
         <tr><td>timesubsstpp</td><td>string</td><td>List of hyphen-separated languages with auto-generated stpp subtitles</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>timesubsdur</td><td>int</td><td>Cue duration of generated time subtitles in ms (default 900)</td><td class="yes">Yes</td><td class="no">No</td></tr>
+        <tr><td>timesubsreg</td><td>0 or 1</td><td>TTML region 0 (bottom) or 1 (top) for time subtitles</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>start or ast</td><td>int >= 0</td><td>Sets the availabilityStartTime</td><td class="no">No</td><td class="yes">Yes</td></tr>
         <tr><td>stop</td><td>int > 0</td><td>Sets the stop time (for time-limited events)</td><td class="no">No</td><td class="yes">Yes</td></tr>
         <tr><td>startrel</td><td>int</td><td>Sets a relative startTime via Location</td><td class="no">No</td><td class="yes">Yes</td></tr>

--- a/cmd/livesim2/app/templates/stpptime.xml
+++ b/cmd/livesim2/app/templates/stpptime.xml
@@ -26,7 +26,7 @@
     </layout>
   </head>
   <body style="s0">
-<div region="r0">
+<div region="r{{.Region}}">
 {{- range .Cues}}
 {{template "stpptimecue.xml" .}}
 {{- end}}


### PR DESCRIPTION
New parameter `timesubsreg` can set TTML region to be 0 or 1 in step template.