### PR TITLE
Feature: new parameter ltgt to set latency target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - parameter `mup` to set minimumUpdatePeriod in MPD
 - new parameter `subsstppreg` can set vertical region
+- new parameter `ltgt` sets latency target in milliseconds
 
 ## [0.5.1] - 2023-03-09
 

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -29,6 +29,7 @@ const (
 	defaultStartNr                  = 0
 	timeShiftBufferDepthMarginS     = 10
 	defaultTimeSubsDurMS            = 900
+	defaultLatencyTargetMS          = 3500
 )
 
 type ServerConfig struct {

--- a/cmd/livesim2/app/handler_livesim_test.go
+++ b/cmd/livesim2/app/handler_livesim_test.go
@@ -209,6 +209,20 @@ func TestParamToMPD(t *testing.T) {
 			wantedStatusCode: http.StatusOK,
 			wantedInMPD:      `minimumUpdatePeriod="PT1S"`,
 		},
+		{
+			desc:             "latency target",
+			mpd:              "testpic_2s/Manifest.mpd",
+			params:           "ltgt_2500/ato_1/chunkdur_0.25/",
+			wantedStatusCode: http.StatusOK,
+			wantedInMPD:      `<Latency referenceId="0" target="2500" max="5000" min="1875"></Latency>`,
+		},
+		{
+			desc:             "latency target",
+			mpd:              "testpic_2s/Manifest.mpd",
+			params:           "ato_1/chunkdur_0.25/",
+			wantedStatusCode: http.StatusOK,
+			wantedInMPD:      `<Latency referenceId="0" target="3500" max="7000" min="2625"></Latency>`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -220,7 +234,8 @@ func TestParamToMPD(t *testing.T) {
 				return
 			}
 			bodyStr := string(body)
-			require.Greater(t, strings.Index(bodyStr, tc.wantedInMPD), -1)
+			//fmt.Println(bodyStr)
+			require.Greater(t, strings.Index(bodyStr, tc.wantedInMPD), -1, "no match in MPD")
 		})
 	}
 }

--- a/cmd/livesim2/app/static/features.html
+++ b/cmd/livesim2/app/static/features.html
@@ -22,7 +22,8 @@
         <tr><td>Max nr requests</td><td>Maximum number of requests per 24h/IP address</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>Non-integral segment duration</td><td>Average segment duration not an integral number of seconds</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>SegmentTimeline input</td><td>Support SegmentTimeline Vod content</td><td class="yes">Yes</td><td class="no">No</td></tr>
-        <tr><td>Support for 29.97Hz video</td><td>Allow non-matching audio/video durations</td><td class="no">No</td><td class="no">No</td></tr>
+        <tr><td>Latency target parameter</td><td>URL parameter to set latency target</td><td class="yes">Yes</td><td class="no">No</td></tr>
+        <tr><td>Support for 29.97Hz video</td><td>Allow non-matching audio/video durations</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>MPD Patch</td><td>Deliver MPD patch as an alternative to full MPD</td><td class="no">No</td><td class="no">No</td></tr>
         <tr><td>Insert Ad content</td><td>Insert a second video and mark as ads</td><td class="no">No</td><td class="no">No</td></tr>
     </table>

--- a/cmd/livesim2/app/static/urlparams.html
+++ b/cmd/livesim2/app/static/urlparams.html
@@ -19,6 +19,7 @@
         <tr><td>segtimeline</td><td>1 (=true)</td><td>Generate live MPD using SegmentTimeline with $Time$</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
         <tr><td>ato</td><td>float or "inf"</td><td>availabilityTimeOffset in seconds (inf = infinity, all segments available)</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
         <tr><td>chunkdur</td><td>float</td><td>Chunk duration for on-the-fly chunking</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
+        <tr><td>ltgt</td><td>int</td><td>Low-latency target in milliseconds</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>timesubsstpp</td><td>string</td><td>List of hyphen-separated languages with auto-generated stpp subtitles</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>timesubsdur</td><td>int</td><td>Cue duration of generated time subtitles in ms (default 900)</td><td class="yes">Yes</td><td class="no">No</td></tr>
         <tr><td>timesubsreg</td><td>0 or 1</td><td>TTML region 0 (bottom) or 1 (top) for time subtitles</td><td class="yes">Yes</td><td class="no">No</td></tr>


### PR DESCRIPTION
With the new URL parameter `ltgt` it is possible to set the latency target and achieve much lower latencies in dash.js.

The min and max latencies are scaled as 75% and 200% of the target latency.

Fixes #25.