### PR TITLE
Publish time reflecting changes in MPD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- PublishTime now reflects the last change in the MPD and not current time.
+- PublishTime now reflects the last change in MPD in ms and not current time.
 
 ## [0.5.1] - 2023-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new parameter `subsstppreg` can set vertical region
 - new parameter `ltgt` sets latency target in milliseconds
 
+### Fixed
+
+- PublishTime now reflects the last change in the MPD and not current time.
+
 ## [0.5.1] - 2023-03-09
 
 ### Fixed

--- a/cmd/livesim2/app/asset.go
+++ b/cmd/livesim2/app/asset.go
@@ -290,28 +290,51 @@ func (a *asset) getVodMPD(mpdName string) (*m.MPD, error) {
 	return m.ReadFromString(md.MPDStr)
 }
 
-func (a *asset) generateTimelineEntry(repID string, startWraps, startRelMS, nowWraps, nowRelMS int) []*m.S {
+type lastSegInfo struct {
+	timescale      uint64
+	startTime, dur uint64
+	nr             int
+}
+
+func (a *asset) generateTimelineEntries(repID string, startWraps, startRelMS, nowWraps, nowRelMS, atoMS int) ([]*m.S, lastSegInfo) {
 	var ss []*m.S
 	rep := a.Reps[repID]
 	segs := rep.segments
 	nrSegs := len(segs)
 
+	ato := uint64(atoMS * rep.MpdTimescale / 1000)
+
 	relStartTime := uint64(startRelMS * rep.MediaTimescale / 1000)
 	relStartIdx := 0
-	if relStartTime < segs[0].endTime {
+	if relStartTime+ato < segs[0].endTime {
 		startWraps--
 		relStartIdx = nrSegs - 1
 	} else {
-		relStartIdx = findHighestIndex(segs, relStartTime)
+		relStartIdx = findFirstFinishedSegIdx(segs, relStartTime+ato)
+		if relStartIdx < 0 {
+			startWraps--
+			relStartIdx = nrSegs - 1
+		}
+	}
+	if startWraps < 0 { // Cannot go before start
+		relStartIdx = 0
+		startWraps = 0
 	}
 
 	relNowTime := uint64(nowRelMS * rep.MediaTimescale / 1000)
 	relNowIdx := 0
-	if relNowTime < segs[0].endTime {
+	if relNowTime+ato < segs[0].endTime {
 		nowWraps--
 		relNowIdx = nrSegs - 1
 	} else {
-		relNowIdx = findHighestIndex(segs, relNowTime)
+		relNowIdx = findFirstFinishedSegIdx(segs, relNowTime+ato)
+		if relNowIdx < 0 {
+			nowWraps--
+			relNowIdx = nrSegs - 1
+		}
+	}
+	if nowWraps < 0 { // end is before start.
+		return nil, lastSegInfo{nr: -1}
 	}
 
 	startNr := startWraps*nrSegs + relStartIdx
@@ -319,19 +342,29 @@ func (a *asset) generateTimelineEntry(repID string, startWraps, startRelMS, nowW
 	t := uint64(rep.duration()*startWraps) + segs[relStartIdx].startTime
 	d := segs[relStartIdx].dur()
 	s := &m.S{T: Ptr(t), D: d}
+	lsi := lastSegInfo{
+		timescale: uint64(rep.MediaTimescale),
+		startTime: t,
+		dur:       d,
+		nr:        startNr,
+	}
 	ss = append(ss, s)
 	for nr := startNr + 1; nr <= nowNr; nr++ {
+		lsi.startTime += d
 		relIdx := nr % nrSegs
 		seg := segs[relIdx]
 		if seg.dur() == d {
 			s.R++
+			lsi.nr = nr
 			continue
 		}
 		d = seg.dur()
 		s = &m.S{D: d}
 		ss = append(ss, s)
+		lsi.dur = d
+		lsi.nr = nr
 	}
-	return ss
+	return ss, lsi
 }
 
 // firstVideoRep returns the first (in alphabetical order) video rep if any present.
@@ -349,11 +382,13 @@ func (a *asset) firstVideoRep() (rep *RepData, ok bool) {
 	return nil, false
 }
 
-// findHighestIndex finds highest segment index finished
-func findHighestIndex(segs []segment, t uint64) int {
-	return sort.Search(len(segs), func(i int) bool {
-		return segs[i].endTime >= t
+// findFirstFinishedSegIdx finds index of first finished segment.
+// Returns -1 if none is finished
+func findFirstFinishedSegIdx(segs []segment, t uint64) int {
+	unfinishedIdx := sort.Search(len(segs), func(i int) bool {
+		return segs[i].endTime > t
 	})
+	return unfinishedIdx - 1
 }
 
 type mediaURIType int

--- a/cmd/livesim2/app/asset.go
+++ b/cmd/livesim2/app/asset.go
@@ -334,7 +334,7 @@ func (a *asset) generateTimelineEntries(repID string, startWraps, startRelMS, no
 		}
 	}
 	if nowWraps < 0 { // end is before start.
-		return nil, lastSegInfo{nr: -1}
+		return nil, lastSegInfo{nr: -1, timescale: uint64(rep.MediaTimescale)}
 	}
 
 	startNr := startWraps*nrSegs + relStartIdx

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -280,6 +280,9 @@ func calcPublishTime(cfg *ResponseConfig, lsi lastSegInfo) float64 {
 
 // lastSegAvailTimeS returns the availabilityTime of the last segment.
 func lastSegAvailTimeS(cfg *ResponseConfig, lsi lastSegInfo) float64 {
+	if lsi.nr < 0 {
+		return 0
+	}
 	availTimeS := float64(lsi.startTime) / float64(lsi.timescale)
 	if cfg.AvailabilityTimeOffsetS != nil {
 		availTimeS -= *cfg.AvailabilityTimeOffsetS

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -285,6 +285,14 @@ func TestPublishTime(t *testing.T) {
 		wantedPublishTime      string
 	}{
 		{
+			desc:              "Timeline with $Time$ 1s after start. No segments",
+			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:           "stream.mpd",
+			segTimelineTime:   true,
+			nowMS:             0,
+			wantedPublishTime: "1970-01-01T00:00:00Z",
+		},
+		{
 			desc:                   "Timeline with $Time$ 3s, ato=1.5, 1.25 segments available",
 			asset:                  "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
 			mpdName:                "stream.mpd",
@@ -310,14 +318,6 @@ func TestPublishTime(t *testing.T) {
 			availabilityTimeOffset: 1.5,
 			nowMS:                  4500,
 			wantedPublishTime:      "1970-01-01T00:00:02.5Z",
-		},
-		{
-			desc:              "Timeline with $Time$ 1s after start. No segments",
-			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
-			mpdName:           "stream.mpd",
-			segTimelineTime:   true,
-			nowMS:             0,
-			wantedPublishTime: "1970-01-01T00:00:00Z",
 		},
 		{
 			desc:              "Timeline with $Time$ 3s after start, one segment",
@@ -374,6 +374,8 @@ func TestPublishTime(t *testing.T) {
 				cfg.ChunkDurS = Ptr(2 - tc.availabilityTimeOffset)
 				cfg.AvailabilityTimeCompleteFlag = false
 			}
+			err := verifyAndFillConfig(cfg)
+			require.NoError(t, err)
 			liveMPD, err := LiveMPD(asset, tc.mpdName, cfg, tc.nowMS)
 			assert.NoError(t, err)
 			assert.Equal(t, m.DateTime(tc.wantedPublishTime), liveMPD.PublishTime)

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	m "github.com/Eyevinn/dash-mpd/mpd"
 	"github.com/Eyevinn/dash-mpd/xml"
@@ -184,5 +185,198 @@ func TestSegmentTimes(t *testing.T) {
 				assert.True(t, 29 <= nrSegs && nrSegs <= 32, "nr segments in interval 29 <= x <= 32")
 			}
 		}
+	}
+}
+
+func TestLastAvailableSegment(t *testing.T) {
+	vodFS := os.DirFS("testdata/assets")
+	am := newAssetMgr(vodFS)
+	err := am.discoverAssets()
+	require.NoError(t, err)
+	cases := []struct {
+		desc                   string
+		asset                  string
+		mpdName                string
+		segTimelineTime        bool
+		availabilityTimeOffset float64
+		nowMS                  int
+		wantedSegNr            int
+	}{
+		{
+			desc:                   "Timeline with $Time$ 1hour+1s with chunkdur 0.5",
+			asset:                  "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:                "stream.mpd",
+			segTimelineTime:        true,
+			availabilityTimeOffset: 1.5,
+			nowMS:                  3_601_000,
+			wantedSegNr:            1800,
+		},
+		{
+			desc:            "Timeline with $Time$ 1s after start. No segments",
+			asset:           "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:         "stream.mpd",
+			segTimelineTime: true,
+			nowMS:           0,
+			wantedSegNr:     -1,
+		},
+		{
+			desc:            "Timeline with $Time$ 5s after start, two segment (0, 1)",
+			asset:           "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:         "stream.mpd",
+			segTimelineTime: true,
+			nowMS:           5000,
+			wantedSegNr:     1,
+		},
+		{
+			desc:            "Timeline with $Time$ 1hour after segment generation",
+			asset:           "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:         "stream.mpd",
+			segTimelineTime: true,
+			nowMS:           3_600_000,
+			wantedSegNr:     1799,
+		},
+		{
+			desc:            "Timeline with $Time$ 1hour+1s after segment generation",
+			asset:           "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:         "stream.mpd",
+			segTimelineTime: true,
+			nowMS:           3_601_000,
+			wantedSegNr:     1799,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			asset, ok := am.findAsset(tc.asset)
+			require.True(t, ok)
+			cfg := NewResponseConfig()
+			if tc.segTimelineTime {
+				cfg.SegTimelineFlag = true
+			}
+			if tc.availabilityTimeOffset > 0 {
+				cfg.AvailabilityTimeOffsetS = Ptr(tc.availabilityTimeOffset)
+				cfg.ChunkDurS = Ptr(2 - tc.availabilityTimeOffset)
+				cfg.AvailabilityTimeCompleteFlag = false
+			}
+			tsbd := m.Duration(60 * time.Second)
+			wTimes := calcWrapTimes(asset, cfg, tc.nowMS, tsbd)
+			mpd, err := asset.getVodMPD(tc.mpdName)
+			require.NoError(t, err)
+			as := mpd.Periods[0].AdaptationSets[0]
+			lsi, err := adjustAdaptationSetForTimelineTime(cfg, asset, as, wTimes)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantedSegNr, lsi.nr)
+		})
+	}
+}
+
+func TestPublishTime(t *testing.T) {
+	vodFS := os.DirFS("testdata/assets")
+	am := newAssetMgr(vodFS)
+	err := am.discoverAssets()
+	require.NoError(t, err)
+
+	cases := []struct {
+		desc                   string
+		asset                  string
+		mpdName                string
+		segTimelineTime        bool
+		availabilityTimeOffset float64
+		nowMS                  int
+		wantedPublishTime      string
+	}{
+		{
+			desc:                   "Timeline with $Time$ 3s, ato=1.5, 1.25 segments available",
+			asset:                  "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:                "stream.mpd",
+			segTimelineTime:        true,
+			availabilityTimeOffset: 1.5,
+			nowMS:                  3000,
+			wantedPublishTime:      "1970-01-01T00:00:01Z",
+		},
+		{
+			desc:                   "Timeline with $Time$ 4.25s, ato=1.5, 2 segments available",
+			asset:                  "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:                "stream.mpd",
+			segTimelineTime:        true,
+			availabilityTimeOffset: 1.5,
+			nowMS:                  4250,
+			wantedPublishTime:      "1970-01-01T00:00:01Z",
+		},
+		{
+			desc:                   "Timeline with $Time$ 4.5s, ato=1.5, 3.25 segments available",
+			asset:                  "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:                "stream.mpd",
+			segTimelineTime:        true,
+			availabilityTimeOffset: 1.5,
+			nowMS:                  4500,
+			wantedPublishTime:      "1970-01-01T00:00:03Z",
+		},
+		{
+			desc:              "Timeline with $Time$ 1s after start. No segments",
+			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:           "stream.mpd",
+			segTimelineTime:   true,
+			nowMS:             0,
+			wantedPublishTime: "1970-01-01T00:00:00Z",
+		},
+		{
+			desc:              "Timeline with $Time$ 3s after start, one segment",
+			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:           "stream.mpd",
+			segTimelineTime:   true,
+			nowMS:             3000,
+			wantedPublishTime: "1970-01-01T00:00:02Z",
+		},
+		{
+			desc:              "Timeline with $Time$ 1hour after segment generation",
+			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:           "stream.mpd",
+			segTimelineTime:   true,
+			nowMS:             3_600_000,
+			wantedPublishTime: "1970-01-01T01:00:00Z",
+		},
+		{
+			desc:              "Timeline with $Time$ 1hour+1s after segment generation",
+			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:           "stream.mpd",
+			segTimelineTime:   true,
+			nowMS:             3_601_000,
+			wantedPublishTime: "1970-01-01T01:00:00Z",
+		},
+		{
+			desc:              "SegmentTemplate with $Number$, some segments produced",
+			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:           "stream.mpd",
+			segTimelineTime:   false,
+			nowMS:             10000,
+			wantedPublishTime: "1970-01-01T00:00:00Z",
+		},
+		{
+			desc:              "SegmentTemplate with $Number$, at start",
+			asset:             "WAVE/vectors/cfhd_sets/12.5_25_50/t3/2022-10-17",
+			mpdName:           "stream.mpd",
+			segTimelineTime:   false,
+			nowMS:             0,
+			wantedPublishTime: "1970-01-01T00:00:00Z",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			asset, ok := am.findAsset(tc.asset)
+			require.True(t, ok)
+			assert.Equal(t, 8000, asset.LoopDurMS)
+			cfg := NewResponseConfig()
+			if tc.segTimelineTime {
+				cfg.SegTimelineFlag = true
+			}
+			if tc.availabilityTimeOffset > 0 {
+				cfg.AvailabilityTimeOffsetS = Ptr(tc.availabilityTimeOffset)
+				cfg.ChunkDurS = Ptr(2 - tc.availabilityTimeOffset)
+				cfg.AvailabilityTimeCompleteFlag = false
+			}
+			liveMPD, err := LiveMPD(asset, tc.mpdName, cfg, tc.nowMS)
+			assert.NoError(t, err)
+			assert.Equal(t, m.DateTime(tc.wantedPublishTime), liveMPD.PublishTime)
+		})
 	}
 }

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -291,7 +291,7 @@ func TestPublishTime(t *testing.T) {
 			segTimelineTime:        true,
 			availabilityTimeOffset: 1.5,
 			nowMS:                  3000,
-			wantedPublishTime:      "1970-01-01T00:00:01Z",
+			wantedPublishTime:      "1970-01-01T00:00:00.5Z",
 		},
 		{
 			desc:                   "Timeline with $Time$ 4.25s, ato=1.5, 2 segments available",
@@ -300,7 +300,7 @@ func TestPublishTime(t *testing.T) {
 			segTimelineTime:        true,
 			availabilityTimeOffset: 1.5,
 			nowMS:                  4250,
-			wantedPublishTime:      "1970-01-01T00:00:01Z",
+			wantedPublishTime:      "1970-01-01T00:00:00.5Z",
 		},
 		{
 			desc:                   "Timeline with $Time$ 4.5s, ato=1.5, 3.25 segments available",
@@ -309,7 +309,7 @@ func TestPublishTime(t *testing.T) {
 			segTimelineTime:        true,
 			availabilityTimeOffset: 1.5,
 			nowMS:                  4500,
-			wantedPublishTime:      "1970-01-01T00:00:03Z",
+			wantedPublishTime:      "1970-01-01T00:00:02.5Z",
 		},
 		{
 			desc:              "Timeline with $Time$ 1s after start. No segments",

--- a/cmd/livesim2/app/static/features.html
+++ b/cmd/livesim2/app/static/features.html
@@ -28,6 +28,16 @@
         <tr><td>Insert Ad content</td><td>Insert a second video and mark as ads</td><td class="no">No</td><td class="no">No</td></tr>
     </table>
 
+    <p>There are also differences in details:</p>
+
+    <table id="features">
+        <tr><th>Property</th><th>Description</th><th>livesim2</th><th>livesim1</th></tr>
+        <tr><td>PublishTime</td><td>PublishTime reflects time of latest change in MPD</td><td class="yes">Yes</td><td class="no">No</td></tr>
+        <tr><td>Minimum Update Period default</td><td>SegmentDuration for $Number$</td><td class="yes">Yes</td><td class="no">No</td></tr>
+        <tr><td>Minimum Update Period default</td><td>100years for $Number$</td><td class="no">No</td><td class="yes">Yes</td></tr>
+    </table>
+
+
     <p>It may be good to move this to a wiki or project page for planning of future work.</body></p>
 </body>
 </html>

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.29.0 h1:44S3JjaKmLEE4YIkjzexaP+NzZsudE3Zin5Njn/pYX0=
-google.golang.org/protobuf v1.29.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
 google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=


### PR DESCRIPTION
Before now, the publish time was mapped directly to the UTC time which means that two requests for the same MPD would result in different values.

In this PR, this is changed so that `publishTime` reflects the last change of the MPD.

For an MPD using `SegmentTemplate with $Number$` this is typically
the `availabilityStartTime`, or or the start of an added period.
The case of `SegmentTimeline` is more complex. The algorithm used here is to
look at the availabilityTime of the last segment in the Manifest and use
that to define the publishTime. In case of a non-zero `availabilityTimeOffset` value,
the publishTime is shifted with the same amount to signal that the last segment in
the MPD is available that same amount earlier than its end time.

Fixes #28 