### PR TITLE
feat: support multiple UTC timing methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - parameter `mup` to set minimumUpdatePeriod in MPD
 - new parameter `subsstppreg` can set vertical region
 - new parameter `ltgt` sets latency target in milliseconds
+- parameter `utc` to set one, multiple, or zero UTCTiming methods
 
 ### Fixed
 

--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -17,40 +17,59 @@ const (
 	segmentNumber
 )
 
+type UTCTimingMethod string
+
+const (
+	UtcTimingDirect     UTCTimingMethod = "direct"
+	UtcTimingHead       UTCTimingMethod = "head" // Note, not supported
+	UtcTimingNtp        UTCTimingMethod = "ntp"
+	UtcTimingSntp       UTCTimingMethod = "sntp"
+	UtcTimingHttpXSDate UTCTimingMethod = "httpxsdate"
+	UtcTimingHttpISO    UTCTimingMethod = "httpiso"
+	UtcTimingNone       UTCTimingMethod = "none"
+)
+
+const (
+	UtcTimingNtpServer    = "1.de.pool.ntp.org"
+	UtcTimingSntpServer   = "time.kfki.hu"
+	UtcTimingHttpServer   = "http://time.akamai.com/?iso"
+	UtcTimingHttpServerMS = "http://time.akamai.com/?isoms"
+)
+
 type ResponseConfig struct {
-	BaseURLs                     []string `json:"BaseURLs,omitempty"`
-	UTCTimingMethods             []string `json:"UTCTimingMethods,omitempty"`
-	PeriodDurations              []int    `json:"PeriodDurations,omitempty"`
-	StartTimeS                   int      `json:"StartTimeS"`
-	StopTimeS                    *int     `json:"StopTimeS,omitempty"`
-	TimeOffsetS                  *int     `json:"TimeOffsetS,omitempty"`
-	InitSegAvailOffsetS          *int     `json:"InitSegAvailOffsetS,omitempty"`
-	TimeShiftBufferDepthS        *int     `json:"TimeShiftBufferDepthS,omitempty"`
-	MinimumUpdatePeriodS         *int     `json:"MinimumUpdatePeriodS,omitempty"`
-	PeriodsPerHour               *int     `json:"PeriodsPerHour,omitempty"`
-	XlinkPeriodsPerHour          *int     `json:"XlinkPeriodsPerHour,omitempty"`
-	EtpPeriodsPerHour            *int     `json:"EtpPeriodsPerHour,omitempty"`
-	EtpDuration                  *int     `json:"EtpDuration,omitempty"`
-	PeriodOffset                 *int     `json:"PeriodOffset,omitempty"`
-	SCTE35PerMinute              *int     `json:"SCTE35PerMinute,omitempty"`
-	StartNr                      *int     `json:"StartNr,omitempty"`
-	SuggestedPresentationDelayS  *int     `json:"SuggestedPresentationDelayS,omitempty"`
-	AvailabilityTimeOffsetS      *float64 `json:"AvailabilityTimeOffsetS,omitempty"`
-	ChunkDurS                    *float64 `json:"ChunkDurS,omitempty"`
-	LatencyTargetMS              *int     `json:"LatencyTargetMS,omitempty"`
-	AddLocationFlag              bool     `json:"AddLocationFlag,omitempty"`
-	Tfdt32Flag                   bool     `json:"Tfdt32Flag,omitempty"`
-	ContUpdateFlag               bool     `json:"ContUpdateFlag,omitempty"`
-	InsertAdFlag                 bool     `json:"InsertAdFlag,omitempty"`
-	ContMultiPeriodFlag          bool     `json:"ContMultiPeriodFlag,omitempty"`
-	SegTimelineFlag              bool     `json:"SegTimelineFlag,omitempty"`
-	SegTimelineNrFlag            bool     `json:"SegTimelineNrFlag,omitempty"`
-	SidxFlag                     bool     `json:"SidxFlag,omitempty"`
-	SegTimelineLossFlag          bool     `json:"SegTimelineLossFlag,omitempty"`
-	AvailabilityTimeCompleteFlag bool     `json:"AvailabilityTimeCompleteFlag,omitempty"`
-	TimeSubsStpp                 []string `json:"TimeSubsStppLanguages,omitempty"`
-	TimeSubsDurMS                int      `json:"TimeSubsDurMS,omitempty"`
-	TimeSubsRegion               int      `json:"TimeSubsRegion,omitempty"`
+	BaseURLs                     []string          `json:"BaseURLs,omitempty"`
+	UTCTimingMethods             []UTCTimingMethod `json:"UTCTimingMethods,omitempty"`
+	PeriodDurations              []int             `json:"PeriodDurations,omitempty"`
+	StartTimeS                   int               `json:"StartTimeS"`
+	StopTimeS                    *int              `json:"StopTimeS,omitempty"`
+	TimeOffsetS                  *int              `json:"TimeOffsetS,omitempty"`
+	InitSegAvailOffsetS          *int              `json:"InitSegAvailOffsetS,omitempty"`
+	TimeShiftBufferDepthS        *int              `json:"TimeShiftBufferDepthS,omitempty"`
+	MinimumUpdatePeriodS         *int              `json:"MinimumUpdatePeriodS,omitempty"`
+	PeriodsPerHour               *int              `json:"PeriodsPerHour,omitempty"`
+	XlinkPeriodsPerHour          *int              `json:"XlinkPeriodsPerHour,omitempty"`
+	EtpPeriodsPerHour            *int              `json:"EtpPeriodsPerHour,omitempty"`
+	EtpDuration                  *int              `json:"EtpDuration,omitempty"`
+	PeriodOffset                 *int              `json:"PeriodOffset,omitempty"`
+	SCTE35PerMinute              *int              `json:"SCTE35PerMinute,omitempty"`
+	StartNr                      *int              `json:"StartNr,omitempty"`
+	SuggestedPresentationDelayS  *int              `json:"SuggestedPresentationDelayS,omitempty"`
+	AvailabilityTimeOffsetS      *float64          `json:"AvailabilityTimeOffsetS,omitempty"`
+	ChunkDurS                    *float64          `json:"ChunkDurS,omitempty"`
+	LatencyTargetMS              *int              `json:"LatencyTargetMS,omitempty"`
+	AddLocationFlag              bool              `json:"AddLocationFlag,omitempty"`
+	Tfdt32Flag                   bool              `json:"Tfdt32Flag,omitempty"`
+	ContUpdateFlag               bool              `json:"ContUpdateFlag,omitempty"`
+	InsertAdFlag                 bool              `json:"InsertAdFlag,omitempty"`
+	ContMultiPeriodFlag          bool              `json:"ContMultiPeriodFlag,omitempty"`
+	SegTimelineFlag              bool              `json:"SegTimelineFlag,omitempty"`
+	SegTimelineNrFlag            bool              `json:"SegTimelineNrFlag,omitempty"`
+	SidxFlag                     bool              `json:"SidxFlag,omitempty"`
+	SegTimelineLossFlag          bool              `json:"SegTimelineLossFlag,omitempty"`
+	AvailabilityTimeCompleteFlag bool              `json:"AvailabilityTimeCompleteFlag,omitempty"`
+	TimeSubsStpp                 []string          `json:"TimeSubsStppLanguages,omitempty"`
+	TimeSubsDurMS                int               `json:"TimeSubsDurMS,omitempty"`
+	TimeSubsRegion               int               `json:"TimeSubsRegion,omitempty"`
 }
 
 // NewResponseConfig returns a new ResponseConfig with default values.
@@ -161,7 +180,7 @@ cfgLoop:
 		case "scte35": // Add this many SCTE-35 ad periods every minute
 			cfg.SCTE35PerMinute = sc.AtoiPtr(key, val)
 		case "utc": // Get hyphen-separated list of utc-timing methods and make into list
-			cfg.UTCTimingMethods = strings.Split(val, "-")
+			cfg.UTCTimingMethods = sc.SplitUTCTimings(key, val)
 		case "snr": // Segment startNumber. -1 means default implicit number which ==  1
 			cfg.StartNr = sc.AtoiPtr(key, val)
 		case "ato": // availabilityTimeOffset

--- a/cmd/livesim2/app/configurl_test.go
+++ b/cmd/livesim2/app/configurl_test.go
@@ -21,6 +21,59 @@ func TestProcessURLCfg(t *testing.T) {
 		err         string
 	}{
 		{
+			url:         "/livesim/utc_direct-ntp-sntp-httpxsdate-httpiso/asset.mpd",
+			nowS:        0,
+			contentPart: "asset.mpd",
+			wantedCfg: &ResponseConfig{
+				StartTimeS:                   0,
+				TimeShiftBufferDepthS:        Ptr(defaultTimeShiftBufferDepthS),
+				StartNr:                      Ptr(0),
+				AvailabilityTimeCompleteFlag: true,
+				TimeSubsDurMS:                defaultTimeSubsDurMS,
+				UTCTimingMethods:             []UTCTimingMethod{"direct", "ntp", "sntp", "httpxsdate", "httpiso"},
+			},
+			err: "",
+		},
+		{
+			url:         "/livesim/utc_unknown/asset.mpd",
+			nowS:        0,
+			contentPart: "asset.mpd",
+			wantedCfg: &ResponseConfig{
+				StartTimeS:                   0,
+				TimeShiftBufferDepthS:        Ptr(defaultTimeShiftBufferDepthS),
+				StartNr:                      Ptr(0),
+				AvailabilityTimeCompleteFlag: true,
+				TimeSubsDurMS:                defaultTimeSubsDurMS,
+			},
+			err: `key="utc", val="unknown" is not a valid UTC timing method`,
+		},
+		{
+			url:         "/livesim/utc_head/asset.mpd",
+			nowS:        0,
+			contentPart: "asset.mpd",
+			wantedCfg: &ResponseConfig{
+				StartTimeS:                   0,
+				TimeShiftBufferDepthS:        Ptr(defaultTimeShiftBufferDepthS),
+				StartNr:                      Ptr(0),
+				AvailabilityTimeCompleteFlag: true,
+				TimeSubsDurMS:                defaultTimeSubsDurMS,
+			},
+			err: `key="utc", val="head", UTC timing method "head" not supported`,
+		},
+		{
+			url:         "/livesim/utc_none/asset.mpd",
+			nowS:        0,
+			contentPart: "asset.mpd",
+			wantedCfg: &ResponseConfig{
+				StartTimeS:                   0,
+				TimeShiftBufferDepthS:        Ptr(defaultTimeShiftBufferDepthS),
+				StartNr:                      Ptr(0),
+				AvailabilityTimeCompleteFlag: true,
+				TimeSubsDurMS:                defaultTimeSubsDurMS,
+				UTCTimingMethods:             []UTCTimingMethod{"none"},
+			},
+		},
+		{
 			url:         "/livesim/tsbd_1/asset.mpd",
 			nowS:        0,
 			contentPart: "asset.mpd",

--- a/cmd/livesim2/app/static/urlparams.html
+++ b/cmd/livesim2/app/static/urlparams.html
@@ -44,7 +44,7 @@
         <tr><td>baseurl</td><td>url string</td><td>Add this top-level BaseURL in all configurations</td><td class="no">No</td><td class="yes">Yes</td></tr>
         <tr><td>peroff</td><td>int > 0</td><td>Period offset in seconds</td><td class="no">No</td><td class="yes">Yes</td></tr>
         <tr><td>scte35</td><td>int > 0</td><td>Add these many SCTE-35 splice insert periods every minute</td><td class="no">No</td><td class="yes">Yes</td></tr>
-        <tr><td>utc</td><td>string</td><td>hyphen-separated list of UTCTiming methods and make into list</td><td class="no">No</td><td class="yes">Yes</td></tr>
+        <tr><td>utc</td><td>string</td><td>hyphen-separated list of UTCTiming methods and make into list</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
         <tr><td>snr</td><td>int</td><td>Set startNumber in MPD. -1 translates to no value in MPD (i.e. default = 1)</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
         <tr><td>spd</td><td>int > 0</td><td>suggestedPresentationDelay in seconds</td><td class="yes">Yes</td><td class="yes">Yes</td></tr>
         <tr><td>sidx</td><td>1 (=true)</td><td>Insert sidx box in every segment</td><td class="no">No</td><td class="yes">Yes</td></tr>

--- a/cmd/livesim2/app/strconv.go
+++ b/cmd/livesim2/app/strconv.go
@@ -7,6 +7,7 @@ package app
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 type strConvAccErr struct {
@@ -52,4 +53,26 @@ func (s *strConvAccErr) AtofPosPtr(key, val string) *float64 {
 		return nil
 	}
 	return &valFloat
+}
+
+// SplitUTCTimings splits a hyphen-separated list of UTC timing methods.
+func (s *strConvAccErr) SplitUTCTimings(key, val string) []UTCTimingMethod {
+	if s.err != nil {
+		return nil
+	}
+	vals := strings.Split(val, "-")
+	utcTimingMethods := make([]UTCTimingMethod, len(vals))
+	for i, val := range vals {
+		utcVal := UTCTimingMethod(val)
+		switch utcVal {
+		case UtcTimingDirect, UtcTimingNtp, UtcTimingSntp, UtcTimingHttpXSDate, UtcTimingHttpISO,
+			UtcTimingNone:
+			utcTimingMethods[i] = utcVal
+		case UtcTimingHead:
+			s.err = fmt.Errorf("key=%q, val=%q, UTC timing method %q not supported", key, val, UtcTimingHead)
+		default:
+			s.err = fmt.Errorf("key=%q, val=%q is not a valid UTC timing method", key, val)
+		}
+	}
+	return utcTimingMethods
 }


### PR DESCRIPTION
New URL parameter utc_ allows for setting one or more UTCTiming methods, but also to specify none.
The head method does not need to be supported.

Solves #30.