### PR TITLE
docs: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- nothing yet
+
+## [0.6.0] - 2023-06-10
+
 ### Changed
 
 - moved list URL parameters to [livesim2 wiki](https://github.com/Dash-Industry-Forum/livesim2/wiki/URL-Parameters)
@@ -54,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Dash-Industry-Forum/livesim2/releases/tag/v0.5.0

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ port 443. Automatic TLS configuration using Let's Encrypt is a future enhancemen
 
 ## List of functionality and options
 
-The URL parameters are now listed on this project's Wiki page:
-https://github.com/Dash-Industry-Forum/livesim2/wiki/URL-Parameters
+The URL parameters are now listed on this project's Wiki page
+[URL-parameters](https://github.com/Dash-Industry-Forum/livesim2/wiki/URL-Parameters).
 
 ## Sponsoring
 


### PR DESCRIPTION
### Changed

- moved list URL parameters to [livesim2 wiki](https://github.com/Dash-Industry-Forum/livesim2/wiki/URL-Parameters)

### Added

- new URL parameter `periods` provides multiple periods (n <= 60 per hours, segment and period durations must be compatible)
- new URL parameter `segtimelinenr` turns on SegmentTimeline with `$Number$` addressing
- new URL parameter `mup` to set minimumUpdatePeriod in MPD
- new URL parameter `subsstppreg` can set vertical region
- new URL parameter `ltgt` sets latency target in milliseconds
- new URL parameter `utc` to set one, multiple, or zero UTCTiming methods
- new functionality to handle relative start and stop times by generating a Location element
- new config parameters `scheme` and `host` to be used in generated Location and BaseURL elements

### Fixed

- PublishTime now reflects the last change in MPD in ms and not current time.
- availabilityTimeOffset now gives the right PublishTime value for complete segments
- infinite availabilityTimeOffset for SegmentTimeline now results in an error
- Git version and date inserted properly when running "make build"
- livesim2 version header inserted in every HTTP response
- start-over case with `start` and `stop` time now provides proper dynamic and static MPDs