### PR TITLE
feat: configurable period continuity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - new URL parameter `timesubswvtt` provides generated timing wvtt subtitles
 - `timesubsstpp` and `timesubswvtt` now work with SegmentTimeline
+- `continous_1` URL parameter to signal multiperiod continuity
 
 ## [0.6.0] - 2023-06-10
 

--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -253,6 +253,9 @@ func verifyAndFillConfig(cfg *ResponseConfig, nowMS int) error {
 			return fmt.Errorf("timeShiftBufferDepth %ds is not less than %ds", tsbd, MAX_TIME_SHIFT_BUFFER_DEPTH_S)
 		}
 	}
+	if cfg.ContMultiPeriodFlag && cfg.PeriodsPerHour == nil {
+		return fmt.Errorf("period continuity set, but not multiple periods per hour")
+	}
 
 	return nil
 }

--- a/cmd/livesim2/app/configurl_test.go
+++ b/cmd/livesim2/app/configurl_test.go
@@ -215,6 +215,23 @@ func TestProcessURLCfg(t *testing.T) {
 			err: "",
 		},
 		{
+			url:         "/livesim2/periods_60/continuous_1/asset.mpd",
+			nowMS:       1_000_000,
+			contentPart: "asset.mpd",
+			wantedCfg: &ResponseConfig{
+				URLParts:                     []string{"", "livesim2", "periods_60", "continuous_1", "asset.mpd"},
+				URLContentIdx:                4,
+				StartTimeS:                   0,
+				TimeShiftBufferDepthS:        Ptr(60),
+				StartNr:                      Ptr(0),
+				AvailabilityTimeCompleteFlag: true,
+				TimeSubsDurMS:                defaultTimeSubsDurMS,
+				PeriodsPerHour:               Ptr(60),
+				ContMultiPeriodFlag:          true,
+			},
+			err: "",
+		},
+		{
 			url:         "/livesim2/startrel_-20/stoprel_20/asset.mpd",
 			nowMS:       1_000_000,
 			contentPart: "asset.mpd",

--- a/cmd/livesim2/app/handler_livesim_test.go
+++ b/cmd/livesim2/app/handler_livesim_test.go
@@ -55,6 +55,13 @@ func TestParamToMPD(t *testing.T) {
 			wantedStatusCode: http.StatusOK,
 			wantedInMPD:      `<Latency referenceId="0" target="3500" max="7000" min="2625"></Latency>`,
 		},
+		{
+			desc:             "period continuity",
+			mpd:              "testpic_2s/Manifest.mpd",
+			params:           "periods_60/continuous_1/",
+			wantedStatusCode: http.StatusOK,
+			wantedInMPD:      `<SupplementalProperty schemeIdUri="urn:mpeg:dash:period-continuity:2015" value="1"></SupplementalProperty>`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -183,6 +183,7 @@ func makeMPDStatic(mpd *m.MPD, mpdDurS int) {
 }
 
 // splitPeriod splits the single-period MPD into multiple periods given cfg.PeriodsPerHour
+// continuity is signalled if configured.
 func splitPeriod(mpd *m.MPD, a *asset, cfg *ResponseConfig, wTimes wrapTimes) error {
 	if len(mpd.Periods) != 1 {
 		return fmt.Errorf("not exactly one period in the MPD")
@@ -227,6 +228,13 @@ func splitPeriod(mpd *m.MPD, a *asset, cfg *ResponseConfig, wTimes wrapTimes) er
 				as.SegmentTemplate.SegmentTimeline.S, as.SegmentTemplate.StartNumber = reduceS(inS, startNr, timeScale, periodStart, periodEnd)
 			default:
 				return fmt.Errorf("unknown mpd type")
+			}
+			if cfg.ContMultiPeriodFlag {
+				periodContinuity := m.DescriptorType{
+					SchemeIdUri: "urn:mpeg:dash:period-continuity:2015",
+					Value:       "1",
+				}
+				as.SupplementalProperties = append(as.SupplementalProperties, &periodContinuity)
 			}
 		}
 		periods = append(periods, p)


### PR DESCRIPTION
Inserts supplemental property signalling period continuity if `continuous_1` URL parameter is set.
Resolves #44.

Setting `continuous_1 ` without `periods_x` will cause an error