### PR TITLE
fix: ato_inf makes all segments available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - server startup boost by loading (and writing) previously generated gzipped tar files with representation metadata
   - new configuration parameters `repdataroot` and `writerepdata` to control this
-- HTTP redirect from /livesim to /livesim2 and /dash/vod to /vod for compatibility with livesim1
+- HTTP redirect from `/livesim` to `/livesim2` and `/dash/vod` to `/vod` for compatibility with livesim1
 - support assets with stpp subtitles in both text and image format. New test content added
 - support DASH-IF thumbnails including multi-period. New test content added
 - new URL parameter `timesubswvtt` provides generated timing wvtt subtitles
 - `timesubsstpp` and `timesubswvtt` now work with SegmentTimeline
 - `continuous_1` URL parameter to signal multiperiod continuity
 - Automatic Let's Encrypt certificates for HTTPS for one or more domains via `domains` parameter
+
+### Fixed
+
+- `/ato_inf` (infinite availability offset) now makes all segments in past and future available
 
 ## [0.6.0] - 2023-06-10
 

--- a/cmd/livesim2/app/asset.go
+++ b/cmd/livesim2/app/asset.go
@@ -135,7 +135,7 @@ func (am *assetMgr) loadAsset(mpdPath string) error {
 				return fmt.Errorf("rep %s of type %s has no segments", rep.Id, r.ContentType)
 			}
 			asset.Reps[r.ID] = r
-			avgSegDurMS := (r.duration() * 1000) / (r.MediaTimescale * len(r.Segments))
+			avgSegDurMS := int(math.Round(float64(r.duration()*1000.0)) / float64((r.MediaTimescale * len(r.Segments))))
 			if asset.SegmentDurMS == 0 || avgSegDurMS < asset.SegmentDurMS {
 				asset.SegmentDurMS = avgSegDurMS
 			}

--- a/cmd/livesim2/app/livesegment.go
+++ b/cmd/livesim2/app/livesegment.go
@@ -127,11 +127,11 @@ func findSegMetaFromTime(a *asset, rep *RepData, time uint64, cfg *ResponseConfi
 // CheckTimeValidity checks if availTimeS is a valid time given current time and parameters.
 // Returns errors if too early, or too late. availabilityTimeOffset < 0 signals always available.
 func CheckTimeValidity(availTimeS, nowS, timeShiftBufferDepthS, availabilityTimeOffsetS float64) error {
-	if availabilityTimeOffsetS < 0 {
+	if availabilityTimeOffsetS == +math.Inf(1) {
 		return nil // Infinite availability time offset
 	}
-	// Valid interval [nowRel-cfg.tsbd, nowRel) where end-time must be used
 
+	// Valid interval [nowRel-cfg.tsbd, nowRel) where end-time must be used
 	if availabilityTimeOffsetS > 0 {
 		availTimeS -= availabilityTimeOffsetS
 	}

--- a/cmd/livesim2/app/livesegment_test.go
+++ b/cmd/livesim2/app/livesegment_test.go
@@ -7,6 +7,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -245,11 +246,19 @@ func TestAvailabilityTime(t *testing.T) {
 			wantedErr:  "too late",
 		},
 		{
-			desc:       "infinite tsbd",
+			desc:       "infinite ato future",
 			availTimeS: 140,
 			nowS:       120,
 			tsbd:       10,
-			ato:        -1,
+			ato:        math.Inf(1),
+			wantedErr:  "",
+		},
+		{
+			desc:       "infinite ato past",
+			availTimeS: 5,
+			nowS:       120,
+			tsbd:       10,
+			ato:        math.Inf(1),
 			wantedErr:  "",
 		},
 	}


### PR DESCRIPTION
Lets all segments (both from past and into future) available for availabilityTimeOffset=inf (only applies to SegmentTemplate with `$Number$`)

Needed for #59