### PR TITLE
feat: add play links to assets page with automatic scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Prometheus counters and histograms for request timing
+- Direct links to play assets mapped to latest dash.js with http or https scheme
 
 ## [0.7.0] - 2023-08-24
 

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -30,6 +30,7 @@ const (
 	timeShiftBufferDepthMarginS     = 10
 	defaultTimeSubsDurMS            = 900
 	defaultLatencyTargetMS          = 3500
+	defaultPlayURL                  = "reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html?mpd=%s&autoload=true"
 )
 
 type ServerConfig struct {
@@ -47,11 +48,13 @@ type ServerConfig struct {
 	// Domains is a comma-separated list of domains for Let's Encrypt
 	Domains string `json:"domains"`
 	// CertPath is a path to a valid TLS certificate
-	CertPath string `json:"certpath"`
+	CertPath string `json:"-"`
 	// KeyPath is a path to a valid private TLS key
-	KeyPath string `json:"keypath"`
+	KeyPath string `json:"-"`
 	// If Host is set, it will be used instead of autodetected value scheme://host.
 	Host string `json:"host"`
+	// PlayURL is a URL template to play asset (without scheme). %s will be replaced by MPD URL
+	PlayURL string `json:"playurl"`
 }
 
 var DefaultConfig = ServerConfig{
@@ -65,6 +68,7 @@ var DefaultConfig = ServerConfig{
 	// MetaRoot + means follow VodRoot, _ means no metadata
 	RepDataRoot:  "+",
 	WriteRepData: false,
+	PlayURL:      defaultPlayURL,
 }
 
 type Config struct {
@@ -110,6 +114,7 @@ func LoadConfig(args []string, cwd string) (*ServerConfig, error) {
 	f.String("keypath", k.String("keypath"), "path to TLS private key file (for HTTPS). Use domains instead if possible.")
 	f.String("scheme", k.String("scheme"), "scheme used in Location and BaseURL elements. If empty, it is attempted to be auto-detected")
 	f.String("host", k.String("host"), "host (and possible prefix) used in MPD elements. Overrides auto-detected full scheme://host")
+	f.String("playurl", k.String("playurl"), "URL template to play mpd (without scheme). %s will be replaced by MPD URL")
 	if err := f.Parse(args[1:]); err != nil {
 		return nil, fmt.Errorf("command line parse: %w", err)
 	}

--- a/cmd/livesim2/app/config_test.go
+++ b/cmd/livesim2/app/config_test.go
@@ -33,6 +33,7 @@ func TestConfigFile(t *testing.T) {
 	err = json.Unmarshal(data, &extCfg)
 	extCfg.VodRoot = "/vod2"
 	extCfg.RepDataRoot = extCfg.VodRoot
+	extCfg.PlayURL = defaultPlayURL
 	assert.NoError(t, err)
 	assert.Equal(t, extCfg, *cfg)
 

--- a/cmd/livesim2/app/handler_assets.go
+++ b/cmd/livesim2/app/handler_assets.go
@@ -11,8 +11,9 @@ import (
 )
 
 type AssetsInfo struct {
-	Host   string
-	Assets []*AssetInfo
+	Host    string
+	PlayURL string
+	Assets  []*AssetInfo
 }
 
 type AssetInfo struct {
@@ -37,9 +38,16 @@ func (s *Server) assetsHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(assets, func(i, j int) bool {
 		return assets[i].AssetPath < assets[j].AssetPath
 	})
+	fh := fullHost(s.Cfg.Host, r)
+	schemePrefix := "http://"
+	if strings.HasPrefix(fh, "https://") {
+		schemePrefix = "https://"
+	}
+	playURL := schemePrefix + s.Cfg.PlayURL
 	aInfo := AssetsInfo{
-		Host:   fullHost(s.Cfg.Host, r),
-		Assets: make([]*AssetInfo, 0, len(assets)),
+		Host:    fh,
+		PlayURL: playURL,
+		Assets:  make([]*AssetInfo, 0, len(assets)),
 	}
 	for _, asset := range assets {
 		mpds := make([]MPDInfo, 0, len(asset.MPDs))

--- a/cmd/livesim2/app/templates/assets.html
+++ b/cmd/livesim2/app/templates/assets.html
@@ -9,6 +9,7 @@
   <body>
     <main class="container">
         {{$h := .Host}}
+        {{$purl := .PlayURL}}
     <hgroup>
         <h1>Available livesim2 live assets!</h1>
         <p>host={{$h}}</p>
@@ -30,7 +31,8 @@
             {{range $m := $a.MPDs}}
             <tr>
                 {{$url := (print $h "/livesim2/" $a.Path "/" $m.Path)}}
-                <td><span data-tooltip="Copy to clipboard" onclick="navigator.clipboard.writeText({{$url}})">{{$m.Path}}</span></td>
+                <td>{{$m.Path}} <span data-tooltip="Copy" onclick="navigator.clipboard.writeText({{$url}})">Copy</span>
+                 <a data-tooltip="Play" href="{{(printf $purl $url)}}" target="_blank">Play</a></td>
                 <td>{{$m.Desc}}</td>
                 <td>{{$m.Dur}}</td>
             </tr>

--- a/cmd/livesim2/app/templates/assets_vod.html
+++ b/cmd/livesim2/app/templates/assets_vod.html
@@ -9,6 +9,7 @@
   <body>
     <main class="container">
         {{$h := .Host}}
+        {{$purl := .PlayURL}}
     <hgroup>
         <h1>Available livesim2 VoD assets!</h1>
         <p>host={{$h}}</p>
@@ -24,7 +25,8 @@
           {{range $m := $a.MPDs}}
           <tr>
             {{$url := (print $h "/vod/" $a.Path "/" $m.Path)}}
-            <td><span data-tooltip="Copy to clipboard" onclick="navigator.clipboard.writeText({{$url}})">{{$m.Path}}</span></td>
+            <td>{{$m.Path}} <span data-tooltip="Copy" onclick="navigator.clipboard.writeText({{$url}})">Copy</span>
+              <a data-tooltip="Play" href="{{(printf $purl $url)}}" target="_blank">Play</a></td>
               <td>{{$m.Desc}}</td>
               <td>{{$m.Dur}}</td>
           </tr>


### PR DESCRIPTION
Add links to start player directly from assets pages.

By default, the player links to go latest dash.js.

The scheme is automatically chosen to be http or https depending on the scheme of the server.