### PR TITLE
fix: utc-timing URLs are now via https

### DIFF
--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -40,8 +40,8 @@ const (
 const (
 	UtcTimingNtpServer    = "1.de.pool.ntp.org"
 	UtcTimingSntpServer   = "time.kfki.hu"
-	UtcTimingHttpServer   = "http://time.akamai.com/?iso"
-	UtcTimingHttpServerMS = "http://time.akamai.com/?isoms"
+	UtcTimingHttpServer   = "https://time.akamai.com/?iso"
+	UtcTimingHttpServerMS = "https://time.akamai.com/?isoms"
 	UtcTimingHeadAsset    = "/static/time.txt"
 )
 


### PR DESCRIPTION
The URLs to https://time.akamai.com/?isoms had http scheme. Now changed.