### PR TITLE
Proxy online player for http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- CORS header for private network
 - Test content with 29.97fps (video only)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Test content with 29.97fps (video only)
 
+### Changed
+
+- The online player is now proxied via /player when livesim2 runs with http
+- The online playURL should now including scheme
+
 ### Fixed
 
 - added muted=true to default playURL
 - HTTP 410 Gone response for segments before timeShiftBufferDepth
 - limited methods in OPTIONS response
+
 
 ## [0.8.0] - 2023-09-22
 

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -31,7 +31,7 @@ const (
 	timeShiftBufferDepthMarginS     = 10
 	defaultTimeSubsDurMS            = 900
 	defaultLatencyTargetMS          = 3500
-	defaultPlayURL                  = "reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true"
+	defaultPlayURL                  = "https://reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true"
 )
 
 type ServerConfig struct {
@@ -56,7 +56,8 @@ type ServerConfig struct {
 	KeyPath string `json:"-"`
 	// If Host is set, it will be used instead of autodetected value scheme://host.
 	Host string `json:"host"`
-	// PlayURL is a URL template to play asset (without scheme). %s will be replaced by MPD URL
+	// PlayURL is a URL template to play asset including player and pattern %s to be replaced by MPD URL
+	// For autoplay, start the player muted.
 	PlayURL string `json:"playurl"`
 }
 
@@ -120,7 +121,7 @@ func LoadConfig(args []string, cwd string) (*ServerConfig, error) {
 	f.String("keypath", k.String("keypath"), "path to TLS private key file (for HTTPS). Use domains instead if possible.")
 	f.String("scheme", k.String("scheme"), "scheme used in Location and BaseURL elements. If empty, it is attempted to be auto-detected")
 	f.String("host", k.String("host"), "host (and possible prefix) used in MPD elements. Overrides auto-detected full scheme://host")
-	f.String("playurl", k.String("playurl"), "URL template to play mpd (without scheme). %s will be replaced by MPD URL")
+	f.String("playurl", k.String("playurl"), "URL template to play mpd. %s will be replaced by MPD URL")
 	if err := f.Parse(args[1:]); err != nil {
 		return nil, fmt.Errorf("command line parse: %w", err)
 	}

--- a/cmd/livesim2/app/middleware.go
+++ b/cmd/livesim2/app/middleware.go
@@ -14,7 +14,7 @@ func addVersionAndCORSHeaders(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("DASH-IF-livesim2", internal.GetVersion())
 		w.Header().Add("Access-Control-Allow-Origin", "*")
-		w.Header().Add("Access-Control-Allow-Private-Network", "true")
+		//w.Header().Add("Access-Control-Allow-Private-Network", "true")
 		w.Header().Add("Timing-Allow-Origin", "*")
 		next.ServeHTTP(w, r)
 	}

--- a/cmd/livesim2/app/middleware.go
+++ b/cmd/livesim2/app/middleware.go
@@ -14,7 +14,6 @@ func addVersionAndCORSHeaders(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("DASH-IF-livesim2", internal.GetVersion())
 		w.Header().Add("Access-Control-Allow-Origin", "*")
-		//w.Header().Add("Access-Control-Allow-Private-Network", "true")
 		w.Header().Add("Timing-Allow-Origin", "*")
 		next.ServeHTTP(w, r)
 	}


### PR DESCRIPTION
It is hard to get a consistent playback of livesim2 content served via http for players with https scheme in their URL.

Therefore, this PR proxies the online player for the http case, while not touching the configured `playURL` for https.

Solves #106.