### PR TITLE
fix: status code and bytecount in request log

### DIFF
--- a/cmd/livesim2/app/start.go
+++ b/cmd/livesim2/app/start.go
@@ -31,11 +31,6 @@ func SetupServer(ctx context.Context, cfg *ServerConfig) (*Server, error) {
 	r.Use(middleware.Recoverer)
 	r.Use(addVersionAndCORSHeaders)
 	prometheusMiddleWare := NewPrometheusMiddleware()
-
-	l := chi.NewRouter()
-	r.Use(prometheusMiddleWare)
-
-	v := chi.NewRouter()
 	r.Use(prometheusMiddleWare)
 
 	// Set a timeout value on the request context (ctx), that will signal
@@ -49,6 +44,8 @@ func SetupServer(ctx context.Context, cfg *ServerConfig) (*Server, error) {
 	r.Mount("/metrics", promhttp.Handler())
 
 	var reqLimiter *IPRequestLimiter
+	l := chi.NewRouter()
+	v := chi.NewRouter()
 	if cfg.MaxRequests > 0 {
 		reqLimiter = NewIPRequestLimiter(cfg.MaxRequests, time.Duration(cfg.ReqLimitInt)*time.Second, time.Now(), cfg.ReqLimitLog)
 		ltrMw := NewLimiterMiddleware("Livesim2-Requests", reqLimiter)

--- a/pkg/logging/slog.go
+++ b/pkg/logging/slog.go
@@ -104,8 +104,8 @@ func SlogMiddleWare(l *slog.Logger) func(next http.Handler) http.Handler {
 					l2 = l2.With("bytes_in", bytesIn)
 				}
 				l2.Info("request")
-				next.ServeHTTP(ww, r)
 			}()
+			next.ServeHTTP(ww, r)
 		}
 		return http.HandlerFunc(fn)
 	}


### PR DESCRIPTION
Fix bug introduced when going from zero log to slog.
The status code and bytes written were not captured and written correctly.