### PR TITLE
fix: default UTCTiming mode, and new millisecond versions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,8 @@
         "htmpl",
         "htmx",
         "httpiso",
+        "httpisoms",
+        "httpxsdatems",
         "IDURI",
         "imsc",
         "Inband",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - UTCTiming "mode" `keep` forwards UTCTiming values from VoD MPD
+- UTCTiming "modes" `httpisoms` and `httpxsdatems` for millisecond resolution
+
+### Fixed
+
+- Default UTCTiming signaling schemeIdUri set to "urn:mpeg:dash:utc:http-xsdate:2014"
 
 ## [1.0.1] - 2023-11-15
 

--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -31,22 +31,26 @@ const (
 type UTCTimingMethod string
 
 const (
-	UtcTimingDirect     UTCTimingMethod = "direct"
-	UtcTimingHead       UTCTimingMethod = "head"
-	UtcTimingNtp        UTCTimingMethod = "ntp"
-	UtcTimingSntp       UTCTimingMethod = "sntp"
-	UtcTimingHttpXSDate UTCTimingMethod = "httpxsdate"
-	UtcTimingHttpISO    UTCTimingMethod = "httpiso"
-	UtcTimingNone       UTCTimingMethod = "none"
-	UtcTimingKeep       UTCTimingMethod = "keep"
+	UtcTimingDirect       UTCTimingMethod = "direct"
+	UtcTimingHead         UTCTimingMethod = "head"
+	UtcTimingNtp          UTCTimingMethod = "ntp"
+	UtcTimingSntp         UTCTimingMethod = "sntp"
+	UtcTimingHttpXSDate   UTCTimingMethod = "httpxsdate"
+	UtcTimingHttpXSDateMs UTCTimingMethod = "httpxsdatems"
+	UtcTimingHttpISO      UTCTimingMethod = "httpiso"
+	UtcTimingHttpISOMs    UTCTimingMethod = "httpisoms"
+	UtcTimingNone         UTCTimingMethod = "none"
+	UtcTimingKeep         UTCTimingMethod = "keep"
 )
 
 const (
-	UtcTimingNtpServer    = "1.de.pool.ntp.org"
-	UtcTimingSntpServer   = "time.kfki.hu"
-	UtcTimingHttpServer   = "https://time.akamai.com/?iso"
-	UtcTimingHttpServerMS = "https://time.akamai.com/?isoms"
-	UtcTimingHeadAsset    = "/static/time.txt"
+	UtcTimingNtpServer          = "1.de.pool.ntp.org"
+	UtcTimingSntpServer         = "time.kfki.hu"
+	UtcTimingXSDateHttpServer   = "https://time.akamai.com"
+	UtcTimingXSDateHttpServerMS = "https://time.akamai.com/?ms"
+	UtcTimingISOHttpServer      = "https://time.akamai.com/?iso"
+	UtcTimingISOHttpServerMS    = "https://time.akamai.com/?iso&ms"
+	UtcTimingHeadAsset          = "/static/time.txt"
 )
 
 type ResponseConfig struct {

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -562,8 +562,8 @@ func addUTCTimings(mpd *m.MPD, cfg *ResponseConfig) {
 		// default if none is set. Use HTTP with ms precision.
 		mpd.UTCTimings = []*m.DescriptorType{
 			{
-				SchemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-				Value:       UtcTimingHttpServerMS,
+				SchemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014",
+				Value:       UtcTimingXSDateHttpServerMS,
 			},
 		}
 		return
@@ -592,18 +592,29 @@ func addUTCTimings(mpd *m.MPD, cfg *ResponseConfig) {
 			case UtcTimingHttpXSDate:
 				ut = &m.DescriptorType{
 					SchemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014",
-					Value:       UtcTimingHttpServer,
+					Value:       UtcTimingXSDateHttpServer,
+				}
+			case UtcTimingHttpXSDateMs:
+				ut = &m.DescriptorType{
+					SchemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014",
+					Value:       UtcTimingXSDateHttpServerMS,
 				}
 			case UtcTimingHttpISO:
 				ut = &m.DescriptorType{
 					SchemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-					Value:       UtcTimingHttpServerMS,
+					Value:       UtcTimingISOHttpServer,
+				}
+			case UtcTimingHttpISOMs:
+				ut = &m.DescriptorType{
+					SchemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+					Value:       UtcTimingISOHttpServerMS,
 				}
 			case UtcTimingHead:
 				ut = &m.DescriptorType{
 					SchemeIdUri: "urn:mpeg:dash:utc:http-head:2014",
 					Value:       fmt.Sprintf("%s%s", cfg.Host, UtcTimingHeadAsset),
 				}
+
 			case UtcTimingNone:
 				cfg.UTCTimingMethods = nil
 				return // no UTCTiming elements

--- a/cmd/livesim2/app/strconv.go
+++ b/cmd/livesim2/app/strconv.go
@@ -85,7 +85,9 @@ func (s *strConvAccErr) SplitUTCTimings(key, val string) []UTCTimingMethod {
 	for i, val := range vals {
 		utcVal := UTCTimingMethod(val)
 		switch utcVal {
-		case UtcTimingDirect, UtcTimingNtp, UtcTimingSntp, UtcTimingHttpXSDate, UtcTimingHttpISO,
+		case UtcTimingDirect, UtcTimingNtp, UtcTimingSntp,
+			UtcTimingHttpXSDate, UtcTimingHttpXSDateMs,
+			UtcTimingHttpISO, UtcTimingHttpISOMs,
 			UtcTimingNone, UtcTimingHead:
 			utcTimingMethods[i] = utcVal
 		case UtcTimingKeep:

--- a/cmd/livesim2/app/templates/urlgen.html
+++ b/cmd/livesim2/app/templates/urlgen.html
@@ -86,7 +86,8 @@
 				<input type="text" id="spd" name="spd" value="{{.SuggestedPresentationDelayS}}" />
 			</label>
 			<label for="utc">
-			UTCTiming methods (comma-separated list of: direct, head, ntp, sntp, httpxsdate, httpiso, keep, none.
+			UTCTiming methods (comma-separated list of: direct, head, ntp, sntp, httpxsdate, httpxsdatems,
+			httpiso, httpisoms, keep, none.
 			"keep" keeps values from the VoD MPD and cannot be combined with other values. Default is httpiso)
 				<input type="text" id="utc" name="utc" value="{{.UTCTiming}}" />
 			</label>


### PR DESCRIPTION
### Added

- New UTCTiming "modes" `httpisoms` and `httpxsdatems` for millisecond resolution

### Fixed

- Default UTCTiming signaling schemeIdUri set to "urn:mpeg:dash:utc:http-xsdate:2014"

Solves #141 