### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.1.0] - 2024-01-04
+
 ### Added
 
 - UTCTiming "mode" `keep` forwards UTCTiming values from VoD MPD
@@ -155,7 +159,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v0.8.0...v0.9.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.0.1"     // Should be updated during build
-	commitDate    string = "1700059593" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.1.0"     // Should be updated during build
+	commitDate    string = "1704385703" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Added

- UTCTiming "mode" `keep` forwards UTCTiming values from VoD MPD
- UTCTiming "modes" `httpisoms` and `httpxsdatems` for millisecond resolution
- Support for Marlin DRM and DASH-IF ClearKey in MPD

### Fixed

- Default UTCTiming signaling schemeIdUri set to "urn:mpeg:dash:utc:http-xsdate:2014"