### PR TITLE
fix: set xsdate UTCTiming to ISO format

### DIFF
--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -44,13 +44,24 @@ const (
 )
 
 const (
-	UtcTimingNtpServer          = "1.de.pool.ntp.org"
-	UtcTimingSntpServer         = "time.kfki.hu"
-	UtcTimingXSDateHttpServer   = "https://time.akamai.com"
-	UtcTimingXSDateHttpServerMS = "https://time.akamai.com/?ms"
-	UtcTimingISOHttpServer      = "https://time.akamai.com/?iso"
-	UtcTimingISOHttpServerMS    = "https://time.akamai.com/?iso&ms"
-	UtcTimingHeadAsset          = "/static/time.txt"
+	UtcTimingDirectScheme     = "urn:mpeg:dash:utc:direct:2014"
+	UtcTimingHeadScheme       = "urn:mpeg:dash:utc:head:2014"
+	UtcTimingHttpISOScheme    = "urn:mpeg:dash:utc:iso:2014"
+	UtcTimingHttpXSDateScheme = "urn:mpeg:dash:utc:http-xsdate:2014"
+	UtcTimingNtpDateScheme    = "urn:mpeg:dash:utc:ntp:2014"
+	UtcTimingSntpDateScheme   = "urn:mpeg:dash:utc:sntp:2014"
+)
+
+const (
+	UtcTimingNtpServer  = "1.de.pool.ntp.org"
+	UtcTimingSntpServer = "time.kfki.hu"
+	// UtcTimingHttpXSDateServer format is xs:date, which is essentially ISO 8601
+	UtcTimingXSDateHttpServer   = "https://time.akamai.com/?iso"
+	UtcTimingXSDateHttpServerMS = "https://time.akamai.com/?iso&ms"
+	//UtcTimingHttpISOHttpServer format is ISO 8601
+	UtcTimingISOHttpServer   = "https://time.akamai.com/?iso"
+	UtcTimingISOHttpServerMS = "https://time.akamai.com/?iso&ms"
+	UtcTimingHeadAsset       = "/static/time.txt"
 )
 
 type ResponseConfig struct {

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -365,8 +365,8 @@ func createProducerReferenceTimes(startTimeS int) []*m.ProducerReferenceTimeType
 			Type:             "encoder",
 			WallClockTime:    string(m.ConvertToDateTime(float64(startTimeS))),
 			UTCTiming: &m.DescriptorType{
-				SchemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-				Value:       "https://time.akamai.com/?iso",
+				SchemeIdUri: UtcTimingHttpXSDateScheme,
+				Value:       UtcTimingXSDateHttpServerMS,
 			},
 		},
 	}
@@ -562,7 +562,7 @@ func addUTCTimings(mpd *m.MPD, cfg *ResponseConfig) {
 		// default if none is set. Use HTTP with ms precision.
 		mpd.UTCTimings = []*m.DescriptorType{
 			{
-				SchemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014",
+				SchemeIdUri: UtcTimingHttpXSDateScheme,
 				Value:       UtcTimingXSDateHttpServerMS,
 			},
 		}
@@ -576,42 +576,42 @@ func addUTCTimings(mpd *m.MPD, cfg *ResponseConfig) {
 			switch utcTiming {
 			case UtcTimingDirect:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:direct:2014",
+					SchemeIdUri: UtcTimingDirectScheme,
 					Value:       string(mpd.PublishTime),
 				}
 			case UtcTimingNtp:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:ntp:2014",
+					SchemeIdUri: UtcTimingNtpDateScheme,
 					Value:       UtcTimingNtpServer,
 				}
 			case UtcTimingSntp:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:sntp:2014",
+					SchemeIdUri: UtcTimingSntpDateScheme,
 					Value:       UtcTimingSntpServer,
 				}
 			case UtcTimingHttpXSDate:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014",
+					SchemeIdUri: UtcTimingHttpXSDateScheme,
 					Value:       UtcTimingXSDateHttpServer,
 				}
 			case UtcTimingHttpXSDateMs:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014",
+					SchemeIdUri: UtcTimingHttpXSDateScheme,
 					Value:       UtcTimingXSDateHttpServerMS,
 				}
 			case UtcTimingHttpISO:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+					SchemeIdUri: UtcTimingHttpISOScheme,
 					Value:       UtcTimingISOHttpServer,
 				}
 			case UtcTimingHttpISOMs:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+					SchemeIdUri: UtcTimingHttpISOScheme,
 					Value:       UtcTimingISOHttpServerMS,
 				}
 			case UtcTimingHead:
 				ut = &m.DescriptorType{
-					SchemeIdUri: "urn:mpeg:dash:utc:http-head:2014",
+					SchemeIdUri: UtcTimingHeadScheme,
 					Value:       fmt.Sprintf("%s%s", cfg.Host, UtcTimingHeadAsset),
 				}
 


### PR DESCRIPTION
The UTCTiming formats for ISO and xsdate are very similar, so they now both deliver what is available from Akamai at the iso URL. That should fix the issue for dash.js as reported in #147.