### PR TITLE
fix: derive and set contentType from mimeType if absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Make HTTP OPTIONS method work for all URLs
-- Make --playurl work for general paths
-
 ### Added
 
 - Support for DASH-IF Enhanced Clear Key Content Protection (ECCP)
 - On the fly encryption for ECCP using cbcs or cenc scheme
+
+### Fixed
+
+- Make HTTP OPTIONS method work for all URLs
+- Make --playurl work for general paths
+- Derive and insert contentType if missing
 
 ## [1.1.1] - 2024-01-19
 

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -6,6 +6,7 @@ package app
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"strings"
 
@@ -115,6 +116,8 @@ func LiveMPD(a *asset, mpdName string, cfg *ResponseConfig, nowMS int) (*m.MPD, 
 		b := m.NewBaseURL(baseURL(bNr))
 		period.BaseURLs = append(period.BaseURLs, b)
 	}
+
+	fillContentTypes(a.AssetPath, period)
 
 	adaptationSets := orderAdaptationSetsByContentType(period.AdaptationSets)
 	var refSegEntries segEntries
@@ -692,4 +695,22 @@ func orderAdaptationSetsByContentType(aSets []*m.AdaptationSetType) []*m.Adaptat
 	}
 
 	return outASets
+}
+
+// fillContentTypes fills contentType if not set based on mimeType
+func fillContentTypes(assetPath string, period *m.Period) {
+	for _, as := range period.AdaptationSets {
+		if as.ContentType == "" {
+			switch as.MimeType {
+			case "video/mp4":
+				as.ContentType = "video"
+			case "audio/mp4":
+				as.ContentType = "audio"
+			case "application/mp4":
+				as.ContentType = "text"
+			default:
+				slog.Warn("no contentType and unknown mimeType", "asset", assetPath, "mimeType", as.MimeType)
+			}
+		}
+	}
 }

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Eyevinn/dash-mpd/mpd"
 	m "github.com/Eyevinn/dash-mpd/mpd"
 	"github.com/Eyevinn/dash-mpd/xml"
 	"github.com/stretchr/testify/assert"
@@ -932,4 +933,22 @@ func TestFractionalFramerateMPDs(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestFillContentTypes(t *testing.T) {
+	p := &m.Period{
+		AdaptationSets: []*m.AdaptationSetType{
+			{Id: Ptr(uint32(1)), RepresentationBaseType: m.RepresentationBaseType{MimeType: "video/mp4"}},
+			{Id: Ptr(uint32(2)), RepresentationBaseType: m.RepresentationBaseType{MimeType: "audio/mp4"}},
+			{Id: Ptr(uint32(2)), RepresentationBaseType: m.RepresentationBaseType{MimeType: "application/mp4"}},
+			{Id: Ptr(uint32(4)), ContentType: "audio"},
+			{Id: Ptr(uint32(4))},
+		},
+	}
+	fillContentTypes("theAsset", p)
+	assert.Equal(t, mpd.RFC6838ContentTypeType("video"), p.AdaptationSets[0].ContentType)
+	assert.Equal(t, mpd.RFC6838ContentTypeType("audio"), p.AdaptationSets[1].ContentType)
+	assert.Equal(t, mpd.RFC6838ContentTypeType("text"), p.AdaptationSets[2].ContentType)
+	assert.Equal(t, mpd.RFC6838ContentTypeType("audio"), p.AdaptationSets[3].ContentType)
+	assert.Equal(t, mpd.RFC6838ContentTypeType(""), p.AdaptationSets[4].ContentType)
 }


### PR DESCRIPTION
Add contentType if absent from VoD asset and mimeType is one of "video/mp4", "audio/mp4", or "application/mp4"