### PR TITLE
fix: correct schemes for UTCTiming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Fixed
+
+- Correct UTCTiming schemes for http-iso and http-head
 
 ## [1.2.0] - 2024-02-16
 

--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -32,7 +32,7 @@ type UTCTimingMethod string
 
 const (
 	UtcTimingDirect       UTCTimingMethod = "direct"
-	UtcTimingHead         UTCTimingMethod = "head"
+	UtcTimingHttpHead     UTCTimingMethod = "head"
 	UtcTimingNtp          UTCTimingMethod = "ntp"
 	UtcTimingSntp         UTCTimingMethod = "sntp"
 	UtcTimingHttpXSDate   UTCTimingMethod = "httpxsdate"
@@ -45,8 +45,8 @@ const (
 
 const (
 	UtcTimingDirectScheme     = "urn:mpeg:dash:utc:direct:2014"
-	UtcTimingHeadScheme       = "urn:mpeg:dash:utc:head:2014"
-	UtcTimingHttpISOScheme    = "urn:mpeg:dash:utc:iso:2014"
+	UtcTimingHttpHeadScheme   = "urn:mpeg:dash:utc:http-head:2014"
+	UtcTimingHttpISOScheme    = "urn:mpeg:dash:utc:http-iso:2014"
 	UtcTimingHttpXSDateScheme = "urn:mpeg:dash:utc:http-xsdate:2014"
 	UtcTimingNtpDateScheme    = "urn:mpeg:dash:utc:ntp:2014"
 	UtcTimingSntpDateScheme   = "urn:mpeg:dash:utc:sntp:2014"

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -640,9 +640,9 @@ func addUTCTimings(mpd *m.MPD, cfg *ResponseConfig) {
 					SchemeIdUri: UtcTimingHttpISOScheme,
 					Value:       UtcTimingISOHttpServerMS,
 				}
-			case UtcTimingHead:
+			case UtcTimingHttpHead:
 				ut = &m.DescriptorType{
-					SchemeIdUri: UtcTimingHeadScheme,
+					SchemeIdUri: UtcTimingHttpHeadScheme,
 					Value:       fmt.Sprintf("%s%s", cfg.Host, UtcTimingHeadAsset),
 				}
 

--- a/cmd/livesim2/app/strconv.go
+++ b/cmd/livesim2/app/strconv.go
@@ -88,7 +88,7 @@ func (s *strConvAccErr) SplitUTCTimings(key, val string) []UTCTimingMethod {
 		case UtcTimingDirect, UtcTimingNtp, UtcTimingSntp,
 			UtcTimingHttpXSDate, UtcTimingHttpXSDateMs,
 			UtcTimingHttpISO, UtcTimingHttpISOMs,
-			UtcTimingNone, UtcTimingHead:
+			UtcTimingNone, UtcTimingHttpHead:
 			utcTimingMethods[i] = utcVal
 		case UtcTimingKeep:
 			keepSet = true


### PR DESCRIPTION
The UTCTiming schemes for "http-iso" and "http-head" missed the "http-" part.

Solves #162 