### PR TITLE
Fix ECCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Correct UTCTiming schemes for http-iso and http-head
 - Make urlgen fields for negative test cases easier to fill
+- Fix OPTIONS for livesim2/ path
 
 ## [1.2.0] - 2024-02-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct UTCTiming schemes for http-iso and http-head
 - Make urlgen fields for negative test cases easier to fill
 - Fix OPTIONS for livesim2/ path
+- Fix encryption of segments for representations with previous metadata
 
 ## [1.2.0] - 2024-02-16
 

--- a/cmd/livesim2/app/routes.go
+++ b/cmd/livesim2/app/routes.go
@@ -62,8 +62,8 @@ func (s *Server) Routes(ctx context.Context) error {
 	// LiveRouter is mounted at /livesim2
 	s.LiveRouter.MethodFunc("GET", "/*", s.livesimHandlerFunc)
 	s.LiveRouter.MethodFunc("HEAD", "/*", s.livesimHandlerFunc)
-	s.Router.MethodFunc("OPTIONS", "/*", s.optionsHandlerFunc)
 	s.LiveRouter.MethodFunc("POST", "/*", s.laURLHandlerFunc)
+	s.LiveRouter.MethodFunc("OPTIONS", "/*", s.optionsHandlerFunc)
 	// VodRouter is mounted at /vod
 	s.VodRouter.MethodFunc("GET", "/*", s.vodHandlerFunc)
 	s.VodRouter.MethodFunc("HEAD", "/*", s.vodHandlerFunc)


### PR DESCRIPTION
Fix two problems with ECP when deployed:

1. OPTIONS method for /livesim2/... uRLs
2. encryption of segments for representations with previously generated metdata (RepData)

Solves #165 