### PR TITLE
v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.2.1] - 2024-03-04
+
 ### Fixed
 
 - Correct UTCTiming schemes for http-iso and http-head
@@ -186,7 +190,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.0.1...v1.1.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.2.0"     // Should be updated during build
-	commitDate    string = "1708072810" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.2.1"     // Should be updated during build
+	commitDate    string = "1709584401" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Fixed

- Correct UTCTiming schemes for http-iso and http-head
- Make urlgen fields for negative test cases easier to fill
- Fix OPTIONS for livesim2/ path
- Fix encryption of segments for representations with previous metadata