### PR TITLE
fix: add CORS fields needed for ECCP json request

### DIFF
--- a/cmd/livesim2/app/middleware.go
+++ b/cmd/livesim2/app/middleware.go
@@ -14,6 +14,8 @@ func addVersionAndCORSHeaders(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("DASH-IF-livesim2", internal.GetVersion())
 		w.Header().Add("Access-Control-Allow-Origin", "*")
+		w.Header().Add("Access-Control-Allow-Methods", "POST, GET, HEAD, OPTIONS")
+		w.Header().Add("Access-Control-Allow-Headers", "Content-Type, Accept")
 		w.Header().Add("Timing-Allow-Origin", "*")
 		next.ServeHTTP(w, r)
 	}


### PR DESCRIPTION
Add 

Access-Control-Allow-Methods and 
Access-Control-Allow-Headers

to make the ECCP key handling work.

Part 2 of #165 