### PR TITLE
docs: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.3.0] - 2024-04-23
+
 ### Added
 
 - MPD Patch functionality with new `/patch_ttl` URL configuration
@@ -205,7 +209,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.2.1...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.2.2...v1.3.0
+[1.2.2]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.1.0...v1.1.1

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.2.2"     // Should be updated during build
-	commitDate    string = "1709624124" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.3.0"     // Should be updated during build
+	commitDate    string = "1713872562" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Added

- MPD Patch functionality with new `/patch_ttl` URL configuration
- nowDate query parameter as an alternative to nowMS for MPD and patch

### Fixed

- Timed stpp subtitles EBU-TT-D linePadding
- Update dependencies