### PR TITLE
fix: add Expires header to Patch response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - MPD Patch functionality with new `/patch_ttl` URL configuration
 - nowDate query parameter as an alternative to nowMS for MPD and patch
+- MPD Patch has Expires header equal to publishTime + ttl + 10s
 
 ### Fixed
 

--- a/cmd/livesim2/app/handler_patch.go
+++ b/cmd/livesim2/app/handler_patch.go
@@ -50,7 +50,7 @@ func (s *Server) patchHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	r.URL.RawQuery = newQuery
 	s.livesimHandlerFunc(new, r)
 
-	doc, err := patch.MPDDiff(old.body, new.body)
+	doc, expiration, err := patch.MPDDiff(old.body, new.body)
 	switch {
 	case errors.Is(err, patch.ErrPatchSamePublishTime):
 		http.Error(w, err.Error(), http.StatusTooEarly)
@@ -71,6 +71,7 @@ func (s *Server) patchHandlerFunc(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/dash-patch+xml")
+	w.Header().Set("Expires", expiration.Format(http.TimeFormat))
 	w.Header().Set("Content-Length", strconv.Itoa(len(b)))
 	_, err = w.Write(b)
 	if err != nil {


### PR DESCRIPTION
Set expiration in HTTP response to originalPublishTime + TTL + 10s.
This is also the last time one can fetch the patch.