### PR TITLE
fix: correct LL MPD availabilityTime for SegmentTimeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Fixed
+
+- correct low-latency MPD availabilityTime for SegmentTimeline
 
 ## [1.3.0] - 2024-04-23
 

--- a/cmd/livesim2/app/asset.go
+++ b/cmd/livesim2/app/asset.go
@@ -450,7 +450,7 @@ func (a *asset) generateTimelineEntries(repID string, wt wrapTimes, atoMS int) s
 		mediaTimescale: uint32(rep.MediaTimescale),
 	}
 
-	ato := uint64(atoMS * rep.MpdTimescale / 1000)
+	ato := uint64(atoMS * rep.MediaTimescale / 1000)
 
 	relStartTime := uint64(wt.startRelMS * rep.MediaTimescale / 1000)
 	relStartIdx := 0

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -126,12 +126,12 @@ func LiveMPD(a *asset, mpdName string, cfg *ResponseConfig, nowMS int) (*m.MPD, 
 
 	adaptationSets := orderAdaptationSetsByContentType(period.AdaptationSets)
 	var refSegEntries segEntries
-	for i, as := range adaptationSets {
+	for asIdx, as := range adaptationSets {
 		switch as.ContentType {
 		case "video", "audio":
 			if cfg.PatchTTL > 0 && as.Id == nil {
-				slog.Debug("Inserting ID for AdaptationSet for patch", "contentType", as.ContentType, "id", i+1)
-				as.Id = Ptr(uint32(i + 1))
+				slog.Debug("Inserting ID for AdaptationSet for patch", "contentType", as.ContentType, "id", asIdx+1)
+				as.Id = Ptr(uint32(asIdx + 1))
 			}
 			if cfg.DashIFECCP != "" {
 				if a.refRep.PreEncrypted {
@@ -167,7 +167,7 @@ func LiveMPD(a *asset, mpdName string, cfg *ResponseConfig, nowMS int) (*m.MPD, 
 			return nil, err
 		}
 		var se segEntries
-		if i == 0 {
+		if asIdx == 0 {
 			// Assume that first representation is as good as any, so can be reference
 			refSegEntries = a.generateTimelineEntries(as.Representations[0].Id, wTimes, atoMS)
 			se = refSegEntries
@@ -192,7 +192,7 @@ func LiveMPD(a *asset, mpdName string, cfg *ResponseConfig, nowMS int) (*m.MPD, 
 			if err != nil {
 				return nil, fmt.Errorf("adjustASForTimelineTime: %w", err)
 			}
-			if i == 0 {
+			if asIdx == 0 {
 				mpd.PublishTime = m.ConvertToDateTime(calcPublishTime(cfg, se.lsi))
 			}
 		case timeLineNumber:
@@ -200,7 +200,7 @@ func LiveMPD(a *asset, mpdName string, cfg *ResponseConfig, nowMS int) (*m.MPD, 
 			if err != nil {
 				return nil, fmt.Errorf("adjustASForTimelineNr: %w", err)
 			}
-			if i == 0 {
+			if asIdx == 0 {
 				mpd.PublishTime = m.ConvertToDateTime(calcPublishTime(cfg, se.lsi))
 			}
 		case segmentNumber:

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -473,6 +473,26 @@ func TestPublishTime(t *testing.T) {
 			nowMS:             0,
 			wantedPublishTime: "1970-01-01T00:00:00Z",
 		},
+		{
+			desc:                   "LL SegmentTimeline, early not yet available MPD",
+			asset:                  "testpic_2s",
+			mpdName:                "Manifest.mpd",
+			segTimelineTime:        true,
+			availabilityTimeOffset: 1.75,
+			availabilityStartTime:  0,
+			nowMS:                  10_200,
+			wantedPublishTime:      "1970-01-01T00:00:08.25Z",
+		},
+		{
+			desc:                   "LL SegmentTimeline, early available MPD",
+			asset:                  "testpic_2s",
+			mpdName:                "Manifest.mpd",
+			segTimelineTime:        true,
+			availabilityTimeOffset: 1.75,
+			availabilityStartTime:  0,
+			nowMS:                  10_300,
+			wantedPublishTime:      "1970-01-01T00:00:10.25Z",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
MPDs were not updated and made available according to availabilityTimeOffset. Therefore, dash.js could not play low-latency content for SegmentTimeline as well as for SegmentTemplate with Number.

Solves #181 