### PR TITLE
feat: new endpoint "/version"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - More error logging for segment generation.
 - New endpoint /version responds with livesim2 version
+- Some more links in the Welcome page
 
 ## [1.3.1] - 2024-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - More error logging for segment generation.
+- New endpoint /version responds with livesim2 version
 
 ## [1.3.1] - 2024-05-08
 

--- a/cmd/livesim2/app/handler_index.go
+++ b/cmd/livesim2/app/handler_index.go
@@ -43,3 +43,7 @@ func (s *Server) optionsHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Allow", "OPTIONS, GET, HEAD, POST")
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (s *Server) versionHandlerFunc(w http.ResponseWriter, r *http.Request) {
+	s.jsonResponse(w, struct{ Version string }{Version: internal.GetVersion()}, http.StatusOK)
+}

--- a/cmd/livesim2/app/handler_index_test.go
+++ b/cmd/livesim2/app/handler_index_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Dash-Industry-Forum/livesim2/internal"
 	"github.com/Dash-Industry-Forum/livesim2/pkg/logging"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func TestIndexPageWithHost(t *testing.T) {
 	require.Greater(t, strings.Index(string(body), `href="https://example.com/subfolder/assets"`), 0)
 }
 
-func TestIndexPageWithoutHost(t *testing.T) {
+func TestIndexPageWithoutHostAndVersion(t *testing.T) {
 	cfg := ServerConfig{
 		VodRoot:   "testdata/assets",
 		TimeoutS:  0,
@@ -51,4 +52,9 @@ func TestIndexPageWithoutHost(t *testing.T) {
 	resp, body := testFullRequest(t, ts, "GET", "/", nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Greater(t, strings.Index(string(body), fmt.Sprintf(`href="%s/assets"`, ts.URL)), 0)
+
+	resp, body = testFullRequest(t, ts, "GET", "/version", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	bodyStr := string(body)
+	require.Equal(t, fmt.Sprintf("{\"Version\":\"%s\"}", internal.GetVersion()), bodyStr)
 }

--- a/cmd/livesim2/app/routes.go
+++ b/cmd/livesim2/app/routes.go
@@ -48,6 +48,7 @@ func (s *Server) Routes(ctx context.Context) error {
 	s.Router.MethodFunc("GET", "/healthz", s.healthzHandlerFunc)
 	s.Router.MethodFunc("GET", "/favicon.ico", s.favIconFunc)
 	s.Router.MethodFunc("GET", "/config", s.configHandlerFunc)
+	s.Router.MethodFunc("GET", "/version", s.versionHandlerFunc)
 	s.Router.MethodFunc("GET", "/assets", s.assetsHandlerFunc)
 	s.Router.MethodFunc("GET", "/vod", s.assetsHandlerFunc)
 	s.Router.MethodFunc("GET", "/urlgen/*", s.urlGenHandlerFunc)

--- a/cmd/livesim2/app/templates/welcome.html
+++ b/cmd/livesim2/app/templates/welcome.html
@@ -44,6 +44,7 @@
         <li><a href="{{.Host}}/config">/config</a> to get the current config of the server</li>
         <li><a href="{{.Host}}/metrics">/metrics</a> to get Prometheus metrics for the system and all streaming content requests</li>
         <li><a href="{{.Host}}/reqcount">/reqcount</a> returns the number of requests if a limit is set</li>
+        <li><a href="{{.Host}}/version">/version</a> returns the software version in JSON format</li>
       </ul>
 
       <h4>Further information</h4>

--- a/cmd/livesim2/app/templates/welcome.html
+++ b/cmd/livesim2/app/templates/welcome.html
@@ -40,9 +40,9 @@
         <li><a href="{{.Host}}/assets">/assets</a> provides a list of all loaded assets and their MPDs</li>
         <li><a href="https://github.com/Dash-Industry-Forum/livesim2/wiki/URL-Parameters">livesim2-wiki</a> compares url parameters between livesim2 and livesim1</li>
         <li><a href="{{.Host}}/vod">/vod</a> provides a list of all VoD assets and their MPDs</li>
-        <li><a href="{{.Host}}/healthz">/healthz</a> to check if server is running</li>
-        <li><a href="{{.Host}}/config">/config</a> to get the current config of the server</li>
-        <li><a href="{{.Host}}/metrics">/metrics</a> to get Prometheus metrics for the system and all streaming content requests</li>
+        <li><a href="{{.Host}}/healthz">/healthz</a> returns true if server is running</li>
+        <li><a href="{{.Host}}/config">/config</a> return the current config of the server in JSON format</li>
+        <li><a href="{{.Host}}/metrics">/metrics</a> return  Prometheus metrics for the system and all streaming content requests</li>
         <li><a href="{{.Host}}/reqcount">/reqcount</a> returns the number of requests if a limit is set</li>
         <li><a href="{{.Host}}/version">/version</a> returns the software version in JSON format</li>
       </ul>
@@ -55,6 +55,8 @@
         <li><a href="https://github.com/Dash-Industry-Forum/livesim2"  target="_blank">livesim2 Github project</a></li>
         <li><a href="https://github.com/Dash-Industry-Forum/livesim2/wiki" target="_blank">livesim2 Github Wiki</a></li>
         <li><a href="https://github.com/Dash-Industry-Forum/livesim2/wiki/URL-Parameters" target="_blank">wiki list of url parameters</a></li>
+        <li><a href="https://github.com/orgs/Dash-Industry-Forum/projects/7" target="_blank">Github project for planning new features</a></li>
+        <li><a href="https://dashif.slack.com" target="_blank">The livesim channel in the DASH-IF slack</a></li>
       </ul>
 
       <p>Version: {{.Version}}</p>


### PR DESCRIPTION
New endpoint /version will respond with the software version in JSON format

The software version is also present as an HTTP header in every response, so it is a bit superfluous to add an end point.

This should solve #185 