### PR TITLE
fix: set contentType from mimeType or codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Will now set contentType from mimeType on AdaptationSet or Representation level.
+- If contentType and mimedType is not present, contentType will be set from codecs string.
+
 ## [1.4.1] - 2024-05-28
 
 ### Fixed

--- a/cmd/livesim2/app/asset.go
+++ b/cmd/livesim2/app/asset.go
@@ -133,6 +133,8 @@ func (am *assetMgr) loadAsset(mpdPath string) error {
 	md.Dur = mpd.MediaPresentationDuration.String()
 	asset.MPDs[mpdName] = md
 
+	fillContentTypes(assetPath, mpd.Periods[0])
+
 	for _, as := range mpd.Periods[0].AdaptationSets {
 		if as.SegmentTemplate == nil {
 			return fmt.Errorf("no SegmentTemplate in adaptation set")

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -984,6 +984,12 @@ func TestFillContentTypes(t *testing.T) {
 			{Id: Ptr(uint32(2)), RepresentationBaseType: m.RepresentationBaseType{MimeType: "application/mp4"}},
 			{Id: Ptr(uint32(4)), ContentType: "audio"},
 			{Id: Ptr(uint32(4))},
+			{Id: Ptr(uint32(4)), Representations: []*m.RepresentationType{
+				{RepresentationBaseType: m.RepresentationBaseType{MimeType: "video/mp4"}},
+			}},
+			{Id: Ptr(uint32(4)), Representations: []*m.RepresentationType{
+				{RepresentationBaseType: m.RepresentationBaseType{Codecs: "ac-3"}},
+			}},
 		},
 	}
 	fillContentTypes("theAsset", p)
@@ -992,4 +998,6 @@ func TestFillContentTypes(t *testing.T) {
 	assert.Equal(t, m.RFC6838ContentTypeType("text"), p.AdaptationSets[2].ContentType)
 	assert.Equal(t, m.RFC6838ContentTypeType("audio"), p.AdaptationSets[3].ContentType)
 	assert.Equal(t, m.RFC6838ContentTypeType(""), p.AdaptationSets[4].ContentType)
+	assert.Equal(t, m.RFC6838ContentTypeType("video"), p.AdaptationSets[5].ContentType)
+	assert.Equal(t, m.RFC6838ContentTypeType("audio"), p.AdaptationSets[6].ContentType)
 }


### PR DESCRIPTION
If contentType and mimeType is not available on AdaptationSet level, the representations are scanned for the same field. If still not found, the codecs string is checked. This should allow for more content to be automatically detected.

The contentType is set on the adaptationSet level, so it should be visible in the output dynamic MPD.

Solves #197.