### PR TITLE
feat: improve Dockerfile to insert Version from github into livesim2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM golang:1.21.3-alpine3.18 AS BuildStage
 WORKDIR /work
 COPY . .
 RUN go mod download
-RUN go build  -o ./out/livesim2 ./cmd/livesim2/main.go
+RUN go build  -ldflags "-X github.com/Dash-Industry-Forum/livesim2/internal.commitVersion=$$(git describe --tags HEAD) -X github.com/Dash-Industry-Forum/livesim2/internal.commitDate=$$(git log -1 --format=%ct)" -o ./out/livesim2 ./cmd/livesim2/main.go
 # Deploy Stage
 FROM alpine:latest
 WORKDIR /


### PR DESCRIPTION
Simple update to Dockerfile to insert Version (will be available in Web page, in server responser headers, and as a at the endpoint "/version".

 