### PR TITLE
docs: new link on first page to Wiki page on preparing content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New program `cmaf-ingest-receiver` that can receive one or more CMAF ingest streams
 - New option `--whitelistblocks` for unlimited number of requests to some CIDR blocks
 - Much improved `cmaf-ingest-receiver`
+- Link on starting page to Wiki page on preparing content
 
 ### Fixed
 

--- a/cmd/livesim2/app/templates/welcome.html
+++ b/cmd/livesim2/app/templates/welcome.html
@@ -60,6 +60,7 @@
       <ul>
         <li><a href="https://github.com/Dash-Industry-Forum/livesim2"  target="_blank">livesim2 Github project</a></li>
         <li><a href="https://github.com/Dash-Industry-Forum/livesim2/wiki" target="_blank">livesim2 Github Wiki</a></li>
+        <li><a href="https://github.com/Dash-Industry-Forum/livesim2/wiki/Preparing-Content-for-livesim2" target="_blank">Preparing Content for livesim2</a></li>
         <li><a href="https://github.com/Dash-Industry-Forum/livesim2/wiki/URL-Parameters" target="_blank">wiki list of url parameters</a></li>
         <li><a href="https://github.com/orgs/Dash-Industry-Forum/projects/7" target="_blank">Github project for planning new features</a></li>
         <li><a href="https://dashif.slack.com" target="_blank">The livesim channel in the DASH-IF slack</a></li>


### PR DESCRIPTION
Landing page link to new Wiki page https://github.com/Dash-Industry-Forum/livesim2/wiki/Preparing-Content-for-livesim2

Solves #205 together  with wiki page.