### PR TITLE
V1.5.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ["1.21"]
+        go-version: ["1.22"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Go

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.5.0] - 2024-10-02
+
 ### Added
 
 - Added functions and constants for CMAF file extensions in pkg/cmaf
@@ -252,7 +256,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.4.1...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.3.0...v1.3.1

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.4.1"     // Should be updated during build
-	commitDate    string = "1716895409" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.5.0"     // Should be updated during build
+	commitDate    string = "1727898045" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Added

- Added functions and constants for CMAF file extensions in pkg/cmaf
- Short HEVC + AC-3 test content
- Generation of CMAF ingest streams with a REST-based API
- New program `cmaf-ingest-receiver` that can receive one or more CMAF ingest streams
- New option `--whitelistblocks` for unlimited number of requests to some CIDR blocks
- Much improved `cmaf-ingest-receiver`
- Link on starting page to Wiki page on preparing content

### Fixed

- Will now set contentType from mimeType on AdaptationSet or Representation level.
- If contentType and mimedType is not present, contentType will be set from codecs string.
- Issue with audio resegmentation.

### Changed

- Go version changed to 1.22