### PR TITLE
Version 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet
 
+## [1.5.2] - 2024-11-05
+
+### Fixed
+
+- Segment size bug for ECCP encryption (introduced in v1.5.1)
+- `--timeout` parameter not working. Changed to `--timeoutS`
+
 ## [1.5.1] - 2024-11-01
 
 ### Added
@@ -270,7 +277,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.2...HEAD
+[1.5.2]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.4.0...v1.4.1

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -116,7 +116,7 @@ func LoadConfig(args []string, cwd string) (*ServerConfig, error) {
 	f.String("repdataroot", k.String("repdataroot"), `Representation metadata root directory. "+" copies vodroot value. "-" disables usage.`)
 	f.Bool("writerepdata", k.Bool("writerepdata"), "Write representation metadata if not present")
 	f.String("whitelistblocks", k.String("whitelistblocks"), "comma-separated list of CIDR blocks that are not rate limited")
-	f.Int("timeout", k.Int("timeoutS"), "timeout for all requests (seconds)")
+	f.Int("timeoutS", k.Int("timeouts"), "timeout for all requests (seconds)")
 	f.Int("maxrequests", k.Int("maxrequests"), "max nr of request per IP address per 24 hours")
 	f.String("reqlimitlog", k.String("reqlimitlog"), "path to request limit log file (only written if maxrequests > 0)")
 	f.Int("reqlimitint", k.Int("reqlimitint"), "interval for request limit i seconds (only used if maxrequests > 0)")

--- a/cmd/livesim2/app/livesegment.go
+++ b/cmd/livesim2/app/livesegment.go
@@ -76,6 +76,7 @@ func genLiveSegment(vodFS fs.FS, a *asset, cfg *ResponseConfig, segmentPart stri
 				tfdtSizeDiff := int32(newTfdtSize) - int32(oldTfdtSize)
 				if tfdtSizeDiff != 0 {
 					traf.Trun.DataOffset += tfdtSizeDiff
+					frag.Mdat.StartPos += uint64(tfdtSizeDiff)
 				}
 				if traf.Saio != nil {
 					if saioAfterTfdt(traf) {

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.5.1"     // Should be updated during build
-	commitDate    string = "1730475277" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.5.2"     // Should be updated during build
+	commitDate    string = "1730825548" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Fixed 

- Segment size bug for ECCP encryption (introduced in v1.5.1)
- `--timeout` parameter not working. Changed to `--timeoutS`