### PR TITLE
v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.6.0] - 2024-12-03
+
 ### Added
 
 - On-the-fly encryption with keys from commercial DRM (Widevine and PlayReady) via CPIX document
@@ -285,7 +289,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.2...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.4.1...v1.5.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.5.2"     // Should be updated during build
-	commitDate    string = "1730825548" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.6.0"     // Should be updated during build
+	commitDate    string = "1733237682" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION

### Added

- On-the-fly encryption with keys from commercial DRM (Widevine and PlayReady) via CPIX document
- DRM configuration and URL generation on `urlgen` page
- Unified ECCP and other DRMs using the new URL parameter `/drm_X`

### Fixed

- CLI parameter -h for livesim2