### PR TITLE
Fix: receiver hang indefinitely

### DIFF
--- a/cmd/livesim2/app/cmaf-ingester.go
+++ b/cmd/livesim2/app/cmaf-ingester.go
@@ -683,6 +683,7 @@ func (cs *cmafSource) Write(b []byte) (int, error) {
 		if nrWritten == len(b) {
 			break
 		}
+		<-cs.writeMoreCh
 	}
 	return len(b), nil
 }


### PR DESCRIPTION
After writing the first bytes from buffer, it doesn't "notify" the reader
and continue to write to the buffer without knowing buffer is consumed entirely or not.

The reader hence can send wrong data to receiver. With incorrect box size, it can hang forever.

`testpic` segment size is small (<65536), so it is not affected.

Big thanks to @nhannguyen700 for the fix.
