### PR TITLE
CMAF Ingest Content-Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CMAF ingest of full segments now send Content-Length header
+
 ### Fixed
 
 - endNumber in live MPD (Issue #235)

--- a/cmd/livesim2/app/cmaf-ingester.go
+++ b/cmd/livesim2/app/cmaf-ingester.go
@@ -626,21 +626,7 @@ func (cs *cmafSource) startReadAndSend(ctx context.Context, finishedCh chan stru
 		cs.log.Error("creating request", "err", err)
 		return
 	}
-	req.Header.Set("Connection", "keep-alive")
-	if cs.user != "" || cs.password != "" {
-		req.SetBasicAuth(cs.user, cs.password)
-	}
-	setIngestHeader(req)
-	switch cs.contentType {
-	case "video":
-		req.Header.Set("Content-Type", "video/mp4")
-	case "audio":
-		req.Header.Set("Content-Type", "audio/mp4")
-	case "text":
-		req.Header.Set("Content-Type", "application/mp4")
-	default:
-		cs.log.Warn("unknown content type", "type", cs.contentType)
-	}
+	cs.setReqHeaders(req)
 	cs.req = req
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -660,6 +646,24 @@ func (cs *cmafSource) startReadAndSend(ctx context.Context, finishedCh chan stru
 		resp.Body.Close()
 	}()
 	finishedCh <- struct{}{}
+}
+
+func (cs *cmafSource) setReqHeaders(req *http.Request) {
+	req.Header.Set("Connection", "keep-alive")
+	if cs.user != "" || cs.password != "" {
+		req.SetBasicAuth(cs.user, cs.password)
+	}
+	setIngestHeader(req)
+	switch cs.contentType {
+	case "video":
+		req.Header.Set("Content-Type", "video/mp4")
+	case "audio":
+		req.Header.Set("Content-Type", "audio/mp4")
+	case "text":
+		req.Header.Set("Content-Type", "application/mp4")
+	default:
+		cs.log.Warn("unknown content type", "type", cs.contentType)
+	}
 }
 
 func (cs *cmafSource) Header() http.Header {

--- a/cmd/livesim2/app/cmaf-ingester.go
+++ b/cmd/livesim2/app/cmaf-ingester.go
@@ -580,7 +580,7 @@ func (c *cmafIngester) sendMediaSegment(ctx context.Context, wg *sync.WaitGroup,
 		}
 	}
 	<-writeMoreCh   // Capture final message
-	nrBytesCh <- -1 // Signal that we are done
+	nrBytesCh <- -1 // Signal that we are done to Read (that reads and pushes to remote)
 	<-finishedSendCh
 }
 
@@ -683,7 +683,7 @@ func (cs *cmafSource) Write(b []byte) (int, error) {
 		if nrWritten == len(b) {
 			break
 		}
-		<-cs.writeMoreCh
+		<-cs.writeMoreCh // Wait for OK from reader
 	}
 	return len(b), nil
 }

--- a/cmd/livesim2/app/cmaf-ingester_test.go
+++ b/cmd/livesim2/app/cmaf-ingester_test.go
@@ -44,6 +44,7 @@ func TestCmafIngesterMgr(t *testing.T) {
 		nrTriggers         int
 		expectedNrSegments int
 	}{
+		{"/livesim2/segtimeline_1/ato_1/chunkdur_1000/testpic_2s/Manifest.mpd", mpd.Ptr(int(10000)), false, 2, 4},
 		{"/livesim2/segtimeline_1/testpic_2s/Manifest.mpd", mpd.Ptr(int(10000)), true, 2, 2},
 		{"/livesim2/segtimeline_1/testpic_2s/Manifest.mpd", mpd.Ptr(int(10000)), false, 2, 6},
 	}
@@ -118,8 +119,8 @@ func (s *cmafReceiverTestServer) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	if r.Header.Get("Content-Length") != "" { // Receive full segment based on Content-Length
 		contentLen, _ := strconv.Atoi(r.Header.Get("Content-Length"))
 		buf := make([]byte, contentLen)
-		n, err := r.Body.Read(buf)
-		if err != nil && err != io.EOF {
+		n, err := io.ReadFull(r.Body, buf)
+		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 		if n != contentLen {


### PR DESCRIPTION
CMAF Ingest PUT of segments now use content-length, unless chunk duration is specified, in which case segments are pushed chunk by chunk as produced.

This solves #242.