### PR TITLE
v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- nothing yet
+
+## [1.7.0] - 2025-01-17
+
 ### Changed
 
 - CMAF ingest of full segments now send Content-Length header
@@ -20,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - endNumber in live MPD (Issue #235)
 - urlgen page crashed when no DRM configuration
+- mpd part of play URL in urlgen is now query escaped
+- ContentProtect for DRMs in CPIX file with no configured LaURL
 
 ### Chore
 
@@ -305,7 +311,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.0...v1.5.1

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.6.0"     // Should be updated during build
-	commitDate    string = "1733237682" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.7.0"     // Should be updated during build
+	commitDate    string = "1737105657" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Changed

- CMAF ingest of full segments now send Content-Length header

### Added

- Basic Annex I support for announcing that MPD query parameters should be used in all video segment requests
- Verification that the MPD and the video segments carry the URL-specified query parameters

### Fixed

- endNumber in live MPD (Issue #235)
- urlgen page crashed when no DRM configuration
- mpd part of play URL in urlgen is now query escaped
- ContentProtect for DRMs in CPIX file with no configured LaURL

### Chore

- updated dependencies