### PR TITLE
refactor: update to golangci-lint v2 and fix remarks

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,10 +18,8 @@ jobs:
           go-version: 1.23
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.54.2
-          args: --skip-files=xml
           only-new-issues: true
       - name: go-report-card
         uses: creekorful/goreportcard-action@v1.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+version: "2"
+linters:
+  enable:
+    - lll
+  settings:
+    lll:
+      line-length: 140
+      tab-width: 1
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - urlgen page crashed when no DRM configuration
 - mpd part of play URL in urlgen is now query escaped
 - ContentProtect for DRMs in CPIX file with no configured LaURL
+- Updated to golangci-lint v2 and fixed all remarks
 
 ### Chore
 

--- a/cmd/cmaf-ingest-receiver/app/basicauth_test.go
+++ b/cmd/cmaf-ingest-receiver/app/basicauth_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func finalRemove(dir string) {
+	if err := os.RemoveAll(dir); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to remove temp dir: %s\n", err)
+	}
+}
+
 func TestBasicAuth(t *testing.T) {
 
 	config := Config{
@@ -39,7 +45,8 @@ func TestBasicAuth(t *testing.T) {
 	}
 
 	tmpDir, err := os.MkdirTemp("", "ew-cmaf-ingest-test")
-	defer os.RemoveAll(tmpDir)
+
+	defer finalRemove(tmpDir)
 	assert.NoError(t, err)
 	opts := Options{
 		prefix:                "/upload",

--- a/cmd/cmaf-ingest-receiver/app/channel.go
+++ b/cmd/cmaf-ingest-receiver/app/channel.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -575,10 +576,17 @@ func writeMPD(mpd *m.MPD, filePath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create MPD file: %w", err)
 	}
-	defer fh.Close()
+	defer finalClose(fh)
 	_, err = mpd.Write(fh, "  ", true)
 	if err != nil {
 		return fmt.Errorf("failed to write MPD: %w", err)
 	}
 	return nil
+}
+
+func finalClose(closer io.Closer) {
+	err := closer.Close()
+	if err != nil {
+		slog.Error("Failed to close", "err", err)
+	}
 }

--- a/cmd/cmaf-ingest-receiver/app/segtimelinegen.go
+++ b/cmd/cmaf-ingest-receiver/app/segtimelinegen.go
@@ -116,10 +116,11 @@ func (sg *segmentTimelineGenerator) generateSegmentTimelineNrMPD(log *slog.Logge
 	_, err = manifest.Write(ofh, "  ", true)
 	if err != nil {
 		log.Error("Failed to write MPD", "err", err)
-		ofh.Close()
+		finalClose(ofh)
 		return err
 	}
-	ofh.Close()
+	finalClose(ofh)
+
 	mpdFileName := filepath.Join(ch.dir, timelineNrMPD)
 	err = os.Rename(tmpFile, mpdFileName)
 	if err != nil {

--- a/cmd/dashfetcher/app/fetcher.go
+++ b/cmd/dashfetcher/app/fetcher.go
@@ -173,7 +173,8 @@ func downloadInit(ctx context.Context, segTmpl *m.SegmentTemplateType, outDir, b
 	return cnt
 }
 
-func downloadSegmentTimeLineWithTime(ctx context.Context, stl *m.SegmentTimelineType, mediaPattern, outDir, baseURL string, cnt counts, force bool) counts {
+func downloadSegmentTimeLineWithTime(ctx context.Context, stl *m.SegmentTimelineType, mediaPattern, outDir, baseURL string,
+	cnt counts, force bool) counts {
 	startTime := uint64(0)
 	var err error
 	for _, segItvl := range stl.S {
@@ -203,7 +204,8 @@ func downloadSegmentTimeLineWithTime(ctx context.Context, stl *m.SegmentTimeline
 	return cnt
 }
 
-func downloadSegmentNumber(ctx context.Context, stpl *m.SegmentTemplateType, totDurMS uint32, mediaPattern, outDir, baseURL string, cnt counts, force bool) counts {
+func downloadSegmentNumber(ctx context.Context, stpl *m.SegmentTemplateType, totDurMS uint32, mediaPattern, outDir, baseURL string,
+	cnt counts, force bool) counts {
 	startNr := uint32(1)
 	if stpl.StartNumber != nil {
 		startNr = *stpl.StartNumber

--- a/cmd/livesim2/app/api.go
+++ b/cmd/livesim2/app/api.go
@@ -14,14 +14,16 @@ import (
 
 // CmafIngesterRequest represents the CMAF ingest start request.
 type CmafIngesterSetup struct {
-	User        string `json:"user,omitempty" doc:"User name for basic auth" example:""`
-	PassWord    string `json:"password,omitempty" doc:"Password for basic auth" example:""`
-	DestRoot    string `json:"destRoot" doc:"Destination URL root for assets" example:"https://server.com/upload"`
-	DestName    string `json:"destName" doc:"Destination name for asset" example:"testpic_ingest"`
-	URL         string `json:"livesimURL" doc:"Full livesimURL without scheme and host" example:"/livesim2/segtimeline_1/testpic_2s/Manifest.mpd"`
-	TestNowMS   *int   `json:"testNowMS,omitempty" doc:"Test: start time for step-wise sending"`
-	Duration    *int   `json:"duration,omitempty" doc:"Duration in seconds for the CMAF ingest session" example:"60"`
-	StreamsURLs bool   `json:"streamsURLs,omitempty" doc:"Use streams URLs likes Streams(video.cmfv) instead of individual segment URLs" example:"false"`
+	User     string `json:"user,omitempty" doc:"User name for basic auth" example:""`
+	PassWord string `json:"password,omitempty" doc:"Password for basic auth" example:""`
+	DestRoot string `json:"destRoot" doc:"Destination URL root for assets" example:"https://server.com/upload"`
+	DestName string `json:"destName" doc:"Destination name for asset" example:"testpic_ingest"`
+	//nolint:lll
+	URL       string `json:"livesimURL" doc:"Full livesimURL without scheme and host" example:"/livesim2/segtimeline_1/testpic_2s/Manifest.mpd"`
+	TestNowMS *int   `json:"testNowMS,omitempty" doc:"Test: start time for step-wise sending"`
+	Duration  *int   `json:"duration,omitempty" doc:"Duration in seconds for the CMAF ingest session" example:"60"`
+	//nolint:lll
+	StreamsURLs bool `json:"streamsURLs,omitempty" doc:"Use streams URLs likes Streams(video.cmfv) instead of individual segment URLs" example:"false"`
 }
 
 type CmafIngesterCreateRequest struct {
@@ -180,6 +182,7 @@ func createRouteAPI(s *Server) func(r chi.Router) {
 			Method:      http.MethodGet,
 			Path:        "/cmaf-ingests/{id}/step",
 			Summary:     "Step a CMAF ingest stream one step (for testing)",
+			//nolint: lll
 			Description: "In testing mode (triggered by setting timeNowMS in creation), send the next segment of all tracks for the given stream ID.",
 			Tags:        []string{"CMAF-ingest"},
 			Errors:      []int{404, 410},

--- a/cmd/livesim2/app/asset.go
+++ b/cmd/livesim2/app/asset.go
@@ -616,7 +616,8 @@ func (a *asset) consolidateAsset(logger *slog.Logger) error {
 		}
 		repDurMS := 1000 * rep.duration() / rep.MediaTimescale
 		if repDurMS != a.LoopDurMS {
-			logger.Warn("Duration differs", "representation", rep.ID, "referenceRepresentation", refRep.ID, "refDurMS", a.LoopDurMS, "repDurMS", repDurMS)
+			logger.Warn("Duration differs", "representation", rep.ID, "referenceRepresentation", refRep.ID, "refDurMS",
+				a.LoopDurMS, "repDurMS", repDurMS)
 			badPreEncrypted = true
 		}
 	}

--- a/cmd/livesim2/app/asset_test.go
+++ b/cmd/livesim2/app/asset_test.go
@@ -149,7 +149,7 @@ func copyDir(srcDir, dstDir string) error {
 		return err
 	}
 	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
-		var relPath string = strings.Replace(path, srcDir, "", 1)
+		var relPath = strings.Replace(path, srcDir, "", 1)
 		if relPath == "" {
 			return nil
 		}

--- a/cmd/livesim2/app/cmaf-ingester.go
+++ b/cmd/livesim2/app/cmaf-ingester.go
@@ -372,10 +372,7 @@ func (c *cmafIngester) start(ctx context.Context) {
 		c.log.Info("Next segment availability time", "time", availabilityTime)
 		if c.testNowMS == nil {
 			deltaTime := time.Duration(availabilityTime-int64(nowMS)) * time.Millisecond
-			for {
-				if deltaTime > 0 {
-					break
-				}
+			for deltaTime <= 0 {
 				msg := fmt.Sprintf("Segment availability time in the past: %d", availabilityTime)
 				c.report = append(c.report, msg)
 				c.log.Error(msg)
@@ -565,7 +562,8 @@ func (c *cmafIngester) sendMediaSegments(ctx context.Context, nextSegNr, nowMS i
 
 // sendMediaSegment sends a media segment to the destination URL.
 // The segment may be written in chunks, rather than as a whole.
-func (c *cmafIngester) sendMediaSegment(ctx context.Context, wg *sync.WaitGroup, segPath, segPart, contentType string, segNr, nowMS int, isLast bool) {
+func (c *cmafIngester) sendMediaSegment(ctx context.Context, wg *sync.WaitGroup, segPath, segPart, contentType string,
+	segNr, nowMS int, isLast bool) {
 	defer wg.Done()
 
 	u := fmt.Sprintf("%s/%s", c.dest(), segPath)
@@ -651,7 +649,8 @@ type cmafSource struct {
 	useChunked  bool
 }
 
-func newCmafSource(nrBytesCh chan int, writeMoreCh chan struct{}, log *slog.Logger, url string, contentType, user, password string, useChunked bool) *cmafSource {
+func newCmafSource(nrBytesCh chan int, writeMoreCh chan struct{}, log *slog.Logger, url string, contentType, user, password string,
+	useChunked bool) *cmafSource {
 	cs := cmafSource{
 		url:         url,
 		contentType: contentType,

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -32,7 +32,8 @@ const (
 	timeShiftBufferDepthMarginS     = 10
 	defaultTimeSubsDurMS            = 900
 	defaultLatencyTargetMS          = 3500
-	defaultPlayURL                  = "https://reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true"
+	//nolint:lll
+	defaultPlayURL = "https://reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true"
 )
 
 type ServerConfig struct {
@@ -150,8 +151,8 @@ func LoadConfig(args []string, cwd string) (*ServerConfig, error) {
 
 	// Overload with environment variables
 	err = k.Load(env.Provider("LIVESIM_", ".", func(s string) string {
-		return strings.Replace(strings.ToLower(
-			strings.TrimPrefix(s, "LIVESIM_")), "_", ".", -1)
+		return strings.ReplaceAll(strings.ToLower(
+			strings.TrimPrefix(s, "LIVESIM_")), "_", ".")
 	}), nil)
 	if err != nil {
 		return nil, err

--- a/cmd/livesim2/app/config_test.go
+++ b/cmd/livesim2/app/config_test.go
@@ -41,7 +41,8 @@ func TestConfigFile(t *testing.T) {
 }
 
 func TestCommandLine(t *testing.T) {
-	osArgs := []string{"/path/livesim2", "--loglevel", "debug", "--domains", "livesim2.dashif.org", "--drmcfgfile", "/testdata/drm_config.json"}
+	osArgs := []string{"/path/livesim2", "--loglevel", "debug", "--domains", "livesim2.dashif.org",
+		"--drmcfgfile", "/testdata/drm_config.json"}
 	cfg, err := LoadConfig(osArgs, "/root")
 	assert.NoError(t, err)
 	c := DefaultConfig

--- a/cmd/livesim2/app/handler_laurl.go
+++ b/cmd/livesim2/app/handler_laurl.go
@@ -82,7 +82,7 @@ func (s *Server) laURLHandlerFunc(w http.ResponseWriter, r *http.Request) {
 }
 
 func urlSafeBase64(b64 string) string {
-	b := strings.Replace(b64, "=", "", -1)
+	b := strings.ReplaceAll(b64, "=", "")
 	b = strings.ReplaceAll(b, "+", "-")
 	b = strings.ReplaceAll(b, "/", "_")
 	return b

--- a/cmd/livesim2/app/handler_livesim_test.go
+++ b/cmd/livesim2/app/handler_livesim_test.go
@@ -68,6 +68,7 @@ func TestParamToMPD(t *testing.T) {
 			mpd:              "testpic_2s/Manifest.mpd",
 			params:           "eccp_cbcs/",
 			wantedStatusCode: http.StatusOK,
+			//nolint:lll
 			wantedInMPD: []string{
 				`<ContentProtection xmlns:cenc="urn:mpeg:cenc:2013" cenc:default_KID="2880fe36-e44b-f9bf-79d2-752e234818a5" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cbcs"></ContentProtection>`,
 				`<ContentProtection schemeIdUri="urn:uuid:e2719d58-a985-b3c9-781a-b030af78d30e" value="ClearKey1.0">`,

--- a/cmd/livesim2/app/handler_patch_test.go
+++ b/cmd/livesim2/app/handler_patch_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:lll
 var wantedPatchSegTimelineTime = `<?xml version="1.0" encoding="UTF-8"?>
 <Patch xmlns="urn:mpeg:dash:schema:mpd-patch:2020" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd-patch:2020 DASH-MPD-PATCH.xsd" mpdId="base" originalPublishTime="2024-04-02T15:50:56Z" publishTime="2024-04-02T15:51:40Z">
   <replace sel="/MPD/@publishTime">2024-04-02T15:51:40Z</replace>
@@ -31,6 +32,7 @@ var wantedPatchSegTimelineTime = `<?xml version="1.0" encoding="UTF-8"?>
 </Patch>
 `
 
+//nolint:lll
 var wantedPatchSegTimelineNumberWithAddAtEnd = `<?xml version="1.0" encoding="UTF-8"?>
 <Patch xmlns="urn:mpeg:dash:schema:mpd-patch:2020" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd-patch:2020 DASH-MPD-PATCH.xsd" mpdId="base" originalPublishTime="2024-04-16T07:34:38Z" publishTime="2024-04-16T07:34:56Z">
   <replace sel="/MPD/@publishTime">2024-04-16T07:34:56Z</replace>
@@ -74,21 +76,24 @@ func TestPatchHandler(t *testing.T) {
 		wantedExpires     string
 	}{
 		{
-			desc:              "segTimeline no update yet",
+			desc: "segTimeline no update yet",
+			//nolint:lll
 			url:               "/patch/livesim2/patch_60/segtimeline_1/testpic_2s/Manifest.mpp?publishTime=2024-04-16T07:34:38Z&nowDate=2024-04-16T07:34:39Z",
 			wantedStatusCode:  http.StatusTooEarly,
 			wantedContentType: "text/plain; charset=utf-8",
 			wantedBody:        "",
 		},
 		{
-			desc:              "segTimeline too late",
+			desc: "segTimeline too late",
+			//nolint:lll
 			url:               "/patch/livesim2/patch_60/segtimeline_1/testpic_2s/Manifest.mpp?publishTime=2024-04-16T07:34:38Z&nowDate=2024-04-16T07:44:39Z",
 			wantedStatusCode:  http.StatusGone,
 			wantedContentType: "text/plain; charset=utf-8",
 			wantedBody:        "",
 		},
 		{
-			desc:              "segTimeline",
+			desc: "segTimeline",
+			//nolint:lll
 			url:               "/patch/livesim2/patch_60/segtimeline_1/testpic_2s/Manifest.mpp?publishTime=2024-04-02T15:50:56Z&nowDate=2024-04-02T15:51:40Z",
 			wantedStatusCode:  http.StatusOK,
 			wantedContentType: "application/dash-patch+xml",
@@ -96,7 +101,8 @@ func TestPatchHandler(t *testing.T) {
 			wantedExpires:     "Tue, 02 Apr 2024 15:52:06 GMT",
 		},
 		{
-			desc:              "segTimeline with Number",
+			desc: "segTimeline with Number",
+			//nolint:lll
 			url:               "/patch/livesim2/patch_60/segtimelinenr_1/testpic_2s/Manifest.mpp?publishTime=2024-04-16T07:34:38Z&nowDate=2024-04-16T07:34:57Z",
 			wantedStatusCode:  http.StatusOK,
 			wantedContentType: "application/dash-patch+xml",

--- a/cmd/livesim2/app/handler_urlgen.go
+++ b/cmd/livesim2/app/handler_urlgen.go
@@ -127,6 +127,7 @@ const (
 	defaultTimeSubsReg = "0"
 )
 
+//nolint:lll
 type urlGenData struct {
 	PlayURL                     string
 	URL                         string

--- a/cmd/livesim2/app/keys_test.go
+++ b/cmd/livesim2/app/keys_test.go
@@ -91,7 +91,7 @@ func TestBase64Transform(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			hexID := strings.Replace(c.keyID, "-", "", -1)
+			hexID := strings.ReplaceAll(c.keyID, "-", "")
 			kid, err := id16FromHex(hexID)
 			require.NoError(t, err)
 			b64 := kid.PackBase64()

--- a/cmd/livesim2/app/livempd.go
+++ b/cmd/livesim2/app/livempd.go
@@ -587,7 +587,7 @@ func adjustAdaptationSetForTimelineTime(se segEntries, as *m.AdaptationSetType) 
 	}
 	as.SegmentTemplate.StartNumber = nil
 	as.SegmentTemplate.Duration = nil
-	as.SegmentTemplate.Media = strings.Replace(as.SegmentTemplate.Media, "$Number$", "$Time$", -1)
+	as.SegmentTemplate.Media = strings.ReplaceAll(as.SegmentTemplate.Media, "$Number$", "$Time$")
 	as.SegmentTemplate.Timescale = Ptr(se.mediaTimescale)
 	as.SegmentTemplate.SegmentTimeline.S = se.entries
 	return nil
@@ -599,7 +599,7 @@ func adjustAdaptationSetForTimelineNr(se segEntries, as *m.AdaptationSetType) er
 	}
 	as.SegmentTemplate.StartNumber = nil
 	as.SegmentTemplate.Duration = nil
-	as.SegmentTemplate.Media = strings.Replace(as.SegmentTemplate.Media, "$Time$", "$Number$", -1)
+	as.SegmentTemplate.Media = strings.ReplaceAll(as.SegmentTemplate.Media, "$Time$", "$Number$")
 	as.SegmentTemplate.Timescale = Ptr(se.mediaTimescale)
 	as.SegmentTemplate.SegmentTimeline.S = se.entries
 
@@ -629,7 +629,7 @@ func adjustAdaptationSetForSegmentNumber(cfg *ResponseConfig, a *asset, as *m.Ad
 		startNr := Ptr(uint32(*cfg.StartNr))
 		as.SegmentTemplate.StartNumber = startNr
 	}
-	as.SegmentTemplate.Media = strings.Replace(as.SegmentTemplate.Media, "$Time$", "$Number$", -1)
+	as.SegmentTemplate.Media = strings.ReplaceAll(as.SegmentTemplate.Media, "$Time$", "$Number$")
 	return nil
 }
 

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -172,6 +172,7 @@ func TestLiveMPDWithTimeSubs(t *testing.T) {
 	}
 }
 
+// nolint:lll
 var liveSubEn = "" +
 	` <AdaptationSetType id="100" lang="en" contentType="text" segmentAlignment="true" mimeType="application/mp4" codecs="stpp">
  <Role schemeIdUri="urn:mpeg:dash:role:2011" value="subtitle"></Role>
@@ -737,9 +738,11 @@ func TestAudioSegmentTimeFollowsVideo(t *testing.T) {
 			mpdStlType:            "timelineTime",
 			wantedVideoTimescale:  90000,
 			wantedAudioTimescale:  48000,
-			wantedVideoSegTimings: []segTiming{{t: 89100000, d: 180000}, {89280000, 180000}, {89460000, 180000}, {89640000, 180000}, {89820000, 180000}},
-			wantedAudioSegTimings: []segTiming{{t: 47520768, d: 95232}, {47616000, 96256}, {47712256, 96256}, {47808512, 96256}, {47904768, 95232}},
-			wantedErr:             "",
+			wantedVideoSegTimings: []segTiming{{t: 89100000, d: 180000}, {89280000, 180000}, {89460000, 180000},
+				{89640000, 180000}, {89820000, 180000}},
+			wantedAudioSegTimings: []segTiming{{t: 47520768, d: 95232}, {47616000, 96256}, {47712256, 96256},
+				{47808512, 96256}, {47904768, 95232}},
+			wantedErr: "",
 		},
 	}
 

--- a/cmd/livesim2/app/livesegment.go
+++ b/cmd/livesim2/app/livesegment.go
@@ -593,7 +593,8 @@ func findSegMeta(a *asset, cfg *ResponseConfig, segmentPart string, nowMS int) (
 	return sm, nil
 }
 
-func createAudioSegment(vodFS fs.FS, a *asset, cfg *ResponseConfig, segmentPart string, nowMS int, rep *RepData, segID int) (segOut, error) {
+func createAudioSegment(vodFS fs.FS, a *asset, cfg *ResponseConfig, segmentPart string, nowMS int,
+	rep *RepData, segID int) (segOut, error) {
 	refRep := a.refRep
 	refTimescale := uint64(refRep.MediaTimescale)
 
@@ -761,7 +762,7 @@ func chunkSegment(init *mp4.InitSegment, seg *mp4.MediaSegment, segMeta segMeta,
 	ch := createChunk(seg.Styp, trackID, segMeta.newNr)
 	chunkNr := 1
 	var accChunkDur uint32 = 0
-	var totalDur int = 0
+	var totalDur = 0
 	sampleDecodeTime := segMeta.newTime
 	var thisChunkDur uint32 = 0
 	for i := range fs {

--- a/cmd/livesim2/app/livesegment_test.go
+++ b/cmd/livesim2/app/livesegment_test.go
@@ -97,9 +97,9 @@ func TestLiveSegment(t *testing.T) {
 				mediaTime := nr * 2 * mediaTimescale // This is exact even for audio for nr == 40
 				switch mpdType {
 				case "Number", "TimelineNumber":
-					media = strings.Replace(media, "$NrOrTime$", fmt.Sprintf("%d", nr), -1)
+					media = strings.ReplaceAll(media, "$NrOrTime$", fmt.Sprintf("%d", nr))
 				default: // "TimelineTime":
-					media = strings.Replace(media, "$NrOrTime$", fmt.Sprintf("%d", mediaTime), -1)
+					media = strings.ReplaceAll(media, "$NrOrTime$", fmt.Sprintf("%d", mediaTime))
 				}
 				so, err := genLiveSegment(log, vodFS, asset, cfg, media, nowMS, false /*isLast */)
 				require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestAc3Timing(t *testing.T) {
 	nowMS := 20_000
 	for sNr := 0; sNr <= 5; sNr++ {
 		media := "audio_$NrOrTime$.m4s"
-		media = strings.Replace(media, "$NrOrTime$", fmt.Sprintf("%d", sNr), -1)
+		media = strings.ReplaceAll(media, "$NrOrTime$", fmt.Sprintf("%d", sNr))
 		so, err := genLiveSegment(log, vodFS, asset, cfg, media, nowMS, false /* isLast */)
 		require.NoError(t, err)
 		bmdt := int(so.seg.Fragments[0].Moof.Traf.Tfdt.BaseMediaDecodeTime())
@@ -177,9 +177,9 @@ func TestCheckAudioSegmentTimeAddressing(t *testing.T) {
 				var segMedia string
 				switch mpdType {
 				case "Number", "TimelineNumber":
-					segMedia = strings.Replace(c.media, "$NrOrTime$", fmt.Sprintf("%d", nr), -1)
+					segMedia = strings.ReplaceAll(c.media, "$NrOrTime$", fmt.Sprintf("%d", nr))
 				default:
-					segMedia = strings.Replace(c.media, "$NrOrTime$", fmt.Sprintf("%d", mediaTime), -1)
+					segMedia = strings.ReplaceAll(c.media, "$NrOrTime$", fmt.Sprintf("%d", mediaTime))
 				}
 				so, err := genLiveSegment(log, vodFS, asset, cfg, segMedia, c.nowMS, false /* isLast */)
 				require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestLiveThumbSegment(t *testing.T) {
 			nowMS := 100_000
 			media := tc.media
 			// Always number, even if MPD is timelinetime
-			media = strings.Replace(media, "$NrOrTime$", fmt.Sprintf("%d", tc.reqNr), -1)
+			media = strings.ReplaceAll(media, "$NrOrTime$", fmt.Sprintf("%d", tc.reqNr))
 			so, err := genLiveSegment(log, vodFS, asset, cfg, media, nowMS, false /* isLast */)
 			require.NoError(t, err)
 			origNr := tc.reqNr%tc.nrSegs + 1 // one-based
@@ -698,7 +698,7 @@ func TestSegmentStatusCodeResponse(t *testing.T) {
 				cfg.SegTimelineNrFlag = true
 			}
 			cfg.SegStatusCodes = tc.ss
-			media := strings.Replace(tc.media, "$NrOrTime$", fmt.Sprintf("%d", tc.nrOrTime), -1)
+			media := strings.ReplaceAll(tc.media, "$NrOrTime$", fmt.Sprintf("%d", tc.nrOrTime))
 			rr := httptest.NewRecorder()
 			code, err := writeSegment(context.TODO(), rr, slog.Default(), cfg, nil,
 				vodFS, asset, media, tc.nowMS, nil, false /* isLast */)

--- a/cmd/livesim2/app/timesubs.go
+++ b/cmd/livesim2/app/timesubs.go
@@ -138,7 +138,8 @@ type StppTimeCue struct {
 }
 
 // writeTimeStppMediaSegment return true and tries to write a stpp time subtitle segment if URL matches
-func writeTimeSubsMediaSegment(w http.ResponseWriter, cfg *ResponseConfig, a *asset, segmentPart string, nowMS int, tt *template.Template, isLast bool) (bool, error) {
+func writeTimeSubsMediaSegment(w http.ResponseWriter, cfg *ResponseConfig, a *asset, segmentPart string, nowMS int,
+	tt *template.Template, isLast bool) (bool, error) {
 	prefix := ""
 	var langs []string
 	lang, seg, ok := timeSubsSegmentParts(SUBS_STPP_PREFIX, segmentPart)

--- a/cmd/livesim2/app/timesubs_test.go
+++ b/cmd/livesim2/app/timesubs_test.go
@@ -377,8 +377,9 @@ func TestTimeSubsMediaSegment(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 		},
 		{
-			desc:               "wvtt segment 1800 for segtimeline nr",
-			asset:              "testpic_2s",
+			desc:  "wvtt segment 1800 for segtimeline nr",
+			asset: "testpic_2s",
+			//nolint:lll
 			url:                "/livesim2/segtimelinenr_1/timesubswvtt_en,sv/timesubsdur_600/timesubsreg_1/testpic_2s/timewvtt-en/1800.m4s?nowMS=3610000",
 			segmentMimeType:    "application/mp4",
 			startTime:          3600_000,
@@ -386,8 +387,9 @@ func TestTimeSubsMediaSegment(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 		},
 		{
-			desc:               "wvtt segment 1800 for segtimeline time",
-			asset:              "testpic_2s",
+			desc:  "wvtt segment 1800 for segtimeline time",
+			asset: "testpic_2s",
+			//nolint:lll
 			url:                "/livesim2/segtimeline_1/timesubswvtt_en,sv/timesubsdur_600/timesubsreg_1/testpic_2s/timewvtt-en/3600000.m4s?nowMS=3610000",
 			segmentMimeType:    "application/mp4",
 			startTime:          3600_000,

--- a/internal/mpddata.go
+++ b/internal/mpddata.go
@@ -29,10 +29,7 @@ type MPDData struct {
 func WriteMPDData(dirPath string, name, uri string) error {
 	filePath := path.Join(dirPath, MPDListFile)
 	_, err := os.Stat(filePath)
-	exists := true
-	if os.IsNotExist(err) {
-		exists = false
-	}
+	exists := !os.IsNotExist(err)
 	var mpds []MPDData
 	if exists {
 		data, err := os.ReadFile(filePath)

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -363,10 +363,7 @@ func compareAttributes(old, new []etree.Attr) (attrChange, error) {
 	nIdx := 0
 	var a attrChange
 
-	for {
-		if oIdx >= len(old) && nIdx >= len(new) {
-			break
-		}
+	for oIdx < len(old) || nIdx < len(new) {
 		cmp := 0
 		if oIdx < len(old) && nIdx < len(new) {
 			cmp = compareAttrNames(old[oIdx], new[nIdx])

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -25,6 +25,7 @@ func TestNewPatchDoc(t *testing.T) {
 	require.NotNil(t, pDoc)
 }
 
+//nolint:lll
 const wantedPatchSegmentTimelineTime = (`<?xml version="1.0" encoding="UTF-8"?>` + "\n" +
 	`<Patch xmlns="urn:mpeg:dash:schema:mpd-patch:2020" ` +
 	`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd-patch:2020 DASH-MPD-PATCH.xsd" ` +
@@ -43,6 +44,7 @@ const wantedPatchSegmentTimelineTime = (`<?xml version="1.0" encoding="UTF-8"?>`
 	`  </add>` + "\n" +
 	`</Patch>` + "\n")
 
+//nolint:lll
 const wantedPatchSegmentTimelineNumber = (`<?xml version="1.0" encoding="UTF-8"?>` + "\n" +
 	`<Patch xmlns="urn:mpeg:dash:schema:mpd-patch:2020" ` +
 	`xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd-patch:2020 DASH-MPD-PATCH.xsd" ` +
@@ -136,7 +138,7 @@ func TestDiff(t *testing.T) {
 				d, err := os.ReadFile(c.wantedDiffFile)
 				require.NoError(t, err)
 				wantedDiff = string(d)
-				wantedDiff = strings.Replace(wantedDiff, "\r\n", "\n", -1) // Windows line endings
+				wantedDiff = strings.ReplaceAll(wantedDiff, "\r\n", "\n") // Windows line endings
 			}
 			require.NoError(t, err)
 			require.Equal(t, wantedDiff, out)


### PR DESCRIPTION
Update to golangci-lint v2 and fixed remarks

* neglected return values
* better loop conditions
* too long lines