### PR TITLE
Change version to v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.8.0] - 2025-09-11
+
 ### Added
 
 - HEVC encryption support
@@ -337,7 +341,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.2...v1.6.0
 [1.5.2]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.5.1...v1.5.2

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.7.0"     // Should be updated during build
-	commitDate    string = "1737105657" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.8.0"     // Should be updated during build
+	commitDate    string = "1757601996" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Added

- HEVC encryption support
- AC-4 audio support (including full encryption)
- MPEG-H audio support (including full encryption)
- AC-3 and EC-3 full encryption support
- Support for CMAF-compliant audio edit list
- Documented the CMAF edit list support for both audio and video

### Changed

- Minimal Go version increased to 1.23
- Updated dash-mpd to v0.13.0 (Full DASH Ed. 6 support)
- Updated mp4ff to v0.50.0 (more codecs support)

### Fixed

- One HTTP PUT with Content-Length in cmaf-ingest
- Fixed typo in urlgen template
- Lost error reporting in initial segment parsing
- Added `Access-Control-Expose-Header` to make UTCTiming HEAD work (Issue #251)

### Added

- Test asset with varying segment duration (4s and 8s) with exact 6s average
- Described how to use Dockerfile from Github Container repository (ghcr.io)