### PR TITLE
fix: Handle thumbnails in low-latency chunked mode

### DIFF
--- a/cmd/livesim2/app/handler_livesim.go
+++ b/cmd/livesim2/app/handler_livesim.go
@@ -315,7 +315,7 @@ func writeSegment(ctx context.Context, w http.ResponseWriter, log *slog.Logger, 
 			return code, nil
 		}
 	}
-	if cfg.AvailabilityTimeCompleteFlag {
+	if cfg.AvailabilityTimeCompleteFlag || isImage(segmentPart) {
 		return 0, writeLiveSegment(log, w, cfg, drmCfg, vodFS, a, segmentPart, nowMS, tt, isLast)
 	}
 	// Chunked low-latency mode

--- a/cmd/livesim2/app/handler_livesim_test.go
+++ b/cmd/livesim2/app/handler_livesim_test.go
@@ -164,6 +164,13 @@ func TestFetches(t *testing.T) {
 			wantedContentType: `image/jpeg`,
 		},
 		{
+			desc:              "thumbnail in low-latency mode",
+			url:               "testpic_2s/thumbs/1.jpg?nowMS=12000",
+			params:            "ato_1/chunkdur_1/",
+			wantedStatusCode:  http.StatusOK,
+			wantedContentType: `image/jpeg`,
+		},
+		{
 			desc:              "imsc1 image subtitle",
 			url:               "testpic_2s/imsc1_img_en/300.m4s?nowMS=610000",
 			params:            "",


### PR DESCRIPTION
When thumbnails (`.jpg` files) are requested in low-latency mode (with `chunkdur` parameter set), the server returns a 500 Internal Server Error with the message "no segment data for chunked segment".

Here we patch this to route thumbnail images, or any image for that matter, through the regular flow rather than the chunked low latency flow, which can not handle them properly.