### PR TITLE
feat: Add --writemissingrepdata option (Issue #271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - VVC test content (testpic_2s_vvc)
+- New `--writemissingrepdata` CLI option to generate RepData files only for representations that lack them (Issue #271)
+- Version field in RepData structure to support future format evolution
 
 ### Fixed
 

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -52,6 +52,8 @@ type ServerConfig struct {
 	RepDataRoot string `json:"repdataroot"`
 	// WriteRepData is true if representation metadata should be written (will override existing metadata)
 	WriteRepData bool `json:"writerepdata"`
+	// WriteMissingRepData is true if representation metadata should be written only when missing
+	WriteMissingRepData bool `json:"writemissingrepdata"`
 	// Domains is a comma-separated list of domains for Let's Encrypt
 	Domains string `json:"domains"`
 	// CertPath is a path to a valid TLS certificate
@@ -77,10 +79,11 @@ var DefaultConfig = ServerConfig{
 	ReqLimitInt: defaultReqIntervalS,
 	VodRoot:     "./vod",
 	// MetaRoot + means follow VodRoot, _ means no metadata
-	RepDataRoot:     "+",
-	WriteRepData:    false,
-	PlayURL:         defaultPlayURL,
-	WhiteListBlocks: "",
+	RepDataRoot:         "+",
+	WriteRepData:        false,
+	WriteMissingRepData: false,
+	PlayURL:             defaultPlayURL,
+	WhiteListBlocks:     "",
 }
 
 type Config struct {
@@ -119,6 +122,7 @@ func LoadConfig(args []string, cwd string) (*ServerConfig, error) {
 	f.String("vodroot", k.String("vodroot"), "VoD root directory")
 	f.String("repdataroot", k.String("repdataroot"), `Representation metadata root directory. "+" copies vodroot value. "-" disables usage.`)
 	f.Bool("writerepdata", k.Bool("writerepdata"), "Write representation metadata if not present")
+	f.Bool("writemissingrepdata", k.Bool("writemissingrepdata"), "Write representation metadata only if missing (does not override existing)")
 	f.String("whitelistblocks", k.String("whitelistblocks"), "comma-separated list of CIDR blocks that are not rate limited")
 	f.Int("timeoutS", k.Int("timeouts"), "timeout for all requests (seconds)")
 	f.Int("maxrequests", k.Int("maxrequests"), "max nr of request per IP address per 24 hours")

--- a/cmd/livesim2/app/livempd_test.go
+++ b/cmd/livesim2/app/livempd_test.go
@@ -23,7 +23,7 @@ import (
 func TestLiveMPDStart(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	tmpDir := t.TempDir()
-	am := newAssetMgr(vodFS, tmpDir, false)
+	am := newAssetMgr(vodFS, tmpDir, false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestLiveMPDStart(t *testing.T) {
 
 func TestLiveMPDWithTimeSubs(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -183,7 +183,7 @@ var liveSubEn = "" +
 // TestSegmentTimes checks that the right number of entries are in the SegmentTimeline
 func TestSegmentTimes(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -252,7 +252,7 @@ func TestSegmentTimes(t *testing.T) {
 func TestLastAvailableSegment(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	tmpDir := t.TempDir()
-	am := newAssetMgr(vodFS, tmpDir, true)
+	am := newAssetMgr(vodFS, tmpDir, true, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -370,7 +370,7 @@ func TestLastAvailableSegment(t *testing.T) {
 func TestPublishTime(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	tmpDir := t.TempDir()
-	am := newAssetMgr(vodFS, tmpDir, false)
+	am := newAssetMgr(vodFS, tmpDir, false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -550,7 +550,7 @@ func TestPublishTime(t *testing.T) {
 
 func TestNormalAvailabilityTimeOffset(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -630,7 +630,7 @@ func TestNormalAvailabilityTimeOffset(t *testing.T) {
 
 func TestUTCTiming(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -711,7 +711,7 @@ func segTimingsFromS(ss []*m.S) []segTiming {
 
 func TestAudioSegmentTimeFollowsVideo(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -791,7 +791,7 @@ func TestAudioSegmentTimeFollowsVideo(t *testing.T) {
 // TestMultiPeriod tests that period splitting works as expected
 func TestMultiPeriod(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -904,7 +904,7 @@ func TestMultiPeriod(t *testing.T) {
 
 func TestRelStartStopTimeIntoLocation(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -941,7 +941,7 @@ func TestRelStartStopTimeIntoLocation(t *testing.T) {
 func TestFractionalFramerateMPDs(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	tmpDir := t.TempDir()
-	am := newAssetMgr(vodFS, tmpDir, false)
+	am := newAssetMgr(vodFS, tmpDir, false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -1020,7 +1020,7 @@ func TestFillContentTypes(t *testing.T) {
 func TestEndNumberRemovedFromMPD(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	tmpDir := t.TempDir()
-	am := newAssetMgr(vodFS, tmpDir, false)
+	am := newAssetMgr(vodFS, tmpDir, false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -1045,7 +1045,7 @@ func TestEndNumberRemovedFromMPD(t *testing.T) {
 func TestEditListOffsetMPD(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	tmpDir := t.TempDir()
-	am := newAssetMgr(vodFS, tmpDir, false)
+	am := newAssetMgr(vodFS, tmpDir, false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -1154,7 +1154,7 @@ func TestEditListOffsetMPD(t *testing.T) {
 func TestEditListOffsetAvailabilityTime(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	tmpDir := t.TempDir()
-	am := newAssetMgr(vodFS, tmpDir, false)
+	am := newAssetMgr(vodFS, tmpDir, false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)

--- a/cmd/livesim2/app/livesegment_test.go
+++ b/cmd/livesim2/app/livesegment_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestLiveSegment(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestLiveSegment(t *testing.T) {
 // TestAc3Timing checks that the generated segments end within one frame from nominal segment duration.
 func TestAc3Timing(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	log := slog.Default()
 	err := am.discoverAssets(log)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestAc3Timing(t *testing.T) {
 
 func TestCheckAudioSegmentTimeAddressing(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	log := slog.Default()
 	err := am.discoverAssets(log)
 	require.NoError(t, err)
@@ -195,7 +195,7 @@ func TestCheckAudioSegmentTimeAddressing(t *testing.T) {
 
 func TestLiveThumbSegment(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	log := slog.Default()
 	err := am.discoverAssets(log)
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestLiveThumbSegment(t *testing.T) {
 
 func TestWriteChunkedSegment(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	log := slog.Default()
 	err := am.discoverAssets(log)
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestTTMLTimeShifts(t *testing.T) {
 
 func TestStartNumber(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	log := slog.Default()
 	err := am.discoverAssets(log)
 	require.NoError(t, err)
@@ -460,7 +460,7 @@ func TestStartNumber(t *testing.T) {
 
 func TestLLSegmentAvailability(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	log := slog.Default()
 	err := am.discoverAssets(log)
 	require.NoError(t, err)
@@ -617,7 +617,7 @@ func TestLLSegmentAvailability(t *testing.T) {
 
 func TestSegmentStatusCodeResponse(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -732,7 +732,7 @@ func TestSegmentStatusCodeResponse(t *testing.T) {
 // TestMpeghAssets tests MPEG-H assets with 1.6s segment duration
 func TestMpeghAssets(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)
@@ -900,7 +900,7 @@ func TestMpeghAssets(t *testing.T) {
 func TestMehdBoxRemovedFromInitSegment(t *testing.T) {
 	var drmCfg *drm.DrmConfig = nil
 	vodFS := os.DirFS("testdata/assets")
-	am := newAssetMgr(vodFS, "", false)
+	am := newAssetMgr(vodFS, "", false, false)
 	logger := slog.Default()
 	err := am.discoverAssets(logger)
 	require.NoError(t, err)

--- a/cmd/livesim2/app/start.go
+++ b/cmd/livesim2/app/start.go
@@ -68,7 +68,7 @@ func SetupServer(ctx context.Context, cfg *ServerConfig) (*Server, error) {
 		LiveRouter: l,
 		VodRouter:  v,
 		Cfg:        cfg,
-		assetMgr:   newAssetMgr(vodFS, cfg.RepDataRoot, cfg.WriteRepData),
+		assetMgr:   newAssetMgr(vodFS, cfg.RepDataRoot, cfg.WriteRepData, cfg.WriteMissingRepData),
 		reqLimiter: reqLimiter,
 	}
 


### PR DESCRIPTION
## Summary

Implements Issue #271 by adding a new `--writemissingrepdata` CLI option that selectively generates RepData files only for representations that lack them, avoiding unnecessary regeneration of existing files.

## Changes

- **Added Version field to RepData structure** - Enables future format evolution with a version field (default: 0)
- **New `--writemissingrepdata` CLI option** - Generates RepData only when missing, unlike `--writerepdata` which regenerates all files
- **Smart RepData generation logic** - Updated `loadRep()` to conditionally write based on file existence
- **Comprehensive test coverage** - Added `TestWriteMissingRepData` to verify existing files are not touched
- **Updated all existing tests** - Modified test files to pass the new parameter

## Benefits

This improves efficiency when new assets are added to a VoD root with many existing assets that already have RepData files. Instead of regenerating all RepData files (which can be time-consuming for large asset collections), only missing files are generated.

## Testing

All existing tests pass, plus a new test specifically verifies:
- Missing RepData files are generated
- Existing RepData files are NOT touched (verified by modification time)
- Generated data includes the correct version field

## Usage

```bash
# Generate RepData files only for representations that don't have them
livesim2 --writemissingrepdata --vodroot ./vod
```