### PR TITLE
v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.9.0] - 2026-02-06
+
 ### Added
 
 - VVC test content (testpic_2s_vvc)
@@ -21,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Anchored regex for matching representation
+- Security alerts from CodeQL
+- Race conditions in CMAF Ingest tests
 
 ## [1.8.0] - 2025-09-11
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.8.0"     // Should be updated during build
-	commitDate    string = "1757601996" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.9.0"     // Should be updated during build
+	commitDate    string = "1770277089" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Added

- VVC test content (testpic_2s_vvc)
- New `--writemissingrepdata` CLI option to generate RepData files only for representations that lack them (Issue #271)
- Version field in RepData structure to support future format evolution
- Support for DASH-IF Certurl ContentProtection element
- Pattern support for audio SegmentTimeline following DASH Ed. 6
- New URL options `segtimeline_pattern/` and `segtimelinenr_pattern/`
- URL generator page options for both pattern cases

### Fixed

- Anchored regex for matching representation
- Security alerts from CodeQL
- Race conditions in CMAF Ingest tests