### PR TITLE
fix: chain IV between fragments in cenc encryption (Issue #295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Fixed
+
+- IV reuse across fragments in `cenc` encryption mode by chaining the IV
+  returned by `mp4.EncryptFragment` (Issue #295)
 
 ## [1.9.0] - 2026-02-06
 

--- a/cmd/livesim2/app/livesegment.go
+++ b/cmd/livesim2/app/livesegment.go
@@ -498,10 +498,11 @@ func encryptFrags(log *slog.Logger, cfg *ResponseConfig, drmCfg *drm.DrmConfig,
 	}
 	log.Debug("encrypting with DRM", "scheme", scheme, "kid", hex.EncodeToString(kid), "iv", hex.EncodeToString(iv))
 	for i, f := range frags {
-		err := mp4.EncryptFragment(f, key, iv, ipd)
+		nextIV, err := mp4.EncryptFragment(f, key, iv, ipd)
 		if err != nil {
 			return fmt.Errorf("encrypt fragment %d: %w", i, err)
 		}
+		iv = nextIV
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/Comcast/gots/v2 v2.2.1
 	github.com/Eyevinn/dash-mpd v0.14.1
-	github.com/Eyevinn/mp4ff v0.50.0
+	github.com/Eyevinn/mp4ff v0.52.0
 	github.com/beevik/etree v1.5.0
 	github.com/caddyserver/certmagic v0.22.0
 	github.com/danielgtaylor/huma/v2 v2.31.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Comcast/gots/v2 v2.2.1 h1:LU/SRg7p2KQqVkNqInV7I4MOQKAqvWQP/PSSLtygP2s
 github.com/Comcast/gots/v2 v2.2.1/go.mod h1:firJ11on3eUiGHAhbY5cZNqG0OqhQ1+nSZHfsEEzVVU=
 github.com/Eyevinn/dash-mpd v0.14.1 h1:Pr+SzpNQ3cxEkbGMdyJcdAK/DXCw0h3HLOUE3zFqKyQ=
 github.com/Eyevinn/dash-mpd v0.14.1/go.mod h1:mh/BF4gvesMIYxlNHJMI+H9FLsJYeud9yqGibxcgGpE=
-github.com/Eyevinn/mp4ff v0.50.0 h1:vFlsvpQh5Jfz++cuaeTI90vbID5dAabebvvN/l9lom0=
-github.com/Eyevinn/mp4ff v0.50.0/go.mod h1:hJNUUqOBryLAzUW9wpCJyw2HaI+TCd2rUPhafoS5lgg=
+github.com/Eyevinn/mp4ff v0.52.0 h1:QJUi2PtROeZGkcumbX7f4/91Jz6dlhjeKzpwSdCoYG8=
+github.com/Eyevinn/mp4ff v0.52.0/go.mod h1:LKZAf3K+OtWYdzlvte8uafD/e3g2aK2WcsgVohvjccU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=


### PR DESCRIPTION
## Summary

- Fixes IV/keystream reuse across fragments when encrypting with the `cenc` scheme. Previously the same starting IV was passed to `mp4.EncryptFragment` for every fragment in a segment.
- Adopts the new `mp4.EncryptFragment` signature in mp4ff v0.52.0, which returns the next IV (input IV advanced by the number of encrypted AES blocks), and threads it back into the loop so each subsequent fragment starts from a fresh IV.
- `cbcs` behavior is unchanged: the returned IV equals the input for that scheme.

Fixes Issue #295.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass, including `TestFetches/encrypted_media_segment_cenc` and `..._cbcs`)
- [x] Pre-commit hooks (gofmt, golangci-lint, unit tests) pass