### PR TITLE
feat: honor X-Forwarded-Proto and remove unused --scheme flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Honor the `X-Forwarded-Proto` header (set by a fronting proxy / CDN) when constructing the scheme in MPD `Location` and `BaseURL` elements. Only `http` and `https` are accepted; other values fall back to local TLS detection.
+
 ### Fixed
 
 - IV reuse across fragments in `cenc` encryption mode by chaining the IV
   returned by `mp4.EncryptFragment` (Issue #295)
+
+### Removed
+
+- `--scheme` CLI flag. It was never read by the server and had no effect. Use `--host=https://example.com` (full scheme://host) for a hard override, or rely on `X-Forwarded-Proto` from your proxy.
 
 ## [1.9.0] - 2026-02-06
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ via the command line looks like:
   --certpath string      path to TLS certificate file (for HTTPS). Use domains instead if possible
   --cfg string           path to a JSON config file
   --domains string       One or more DNS domains (comma-separated) for auto certificate from Lets Encrypt
-  --host string          host (and possible prefix) used in MPD elements. Overrides auto-detected full scheme://host
+  --host string          full scheme://host used in MPD Location/BaseURL. If empty, auto-detected from the request (honors X-Forwarded-Proto)
   --keypath string       path to TLS private key file (for HTTPS). Use domains instead if possible.
   --livewindow int       default live window (seconds) (default 300)
   --logformat string     log format [text, json, pretty, discard] (default "text")
@@ -91,7 +91,6 @@ via the command line looks like:
   --repdataroot string   Representation metadata root directory. "+" copies vodroot value. "-" disables usage. (default "+")
   --reqlimitint int      interval for request limit i seconds (only used if maxrequests > 0) (default 86400)
   --reqlimitlog string   path to request limit log file (only written if maxrequests > 0)
-  --scheme string        scheme used in Location and BaseURL elements. If empty, it is attempted to be auto-detected
   --timeout int          timeout for all requests (seconds) (default 60)
   --vodroot string       VoD root directory (default "./vod")
   --writerepdata         Write representation metadata if not present

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -132,8 +132,9 @@ func LoadConfig(args []string, cwd string) (*ServerConfig, error) {
 	f.String("domains", k.String("domains"), "One or more DNS domains (comma-separated) for auto certificate from Let's Encrypt")
 	f.String("certpath", k.String("certpath"), "path to TLS certificate file (for HTTPS). Use domains instead if possible")
 	f.String("keypath", k.String("keypath"), "path to TLS private key file (for HTTPS). Use domains instead if possible.")
-	f.String("scheme", k.String("scheme"), "scheme used in Location and BaseURL elements. If empty, it is attempted to be auto-detected")
-	f.String("host", k.String("host"), "host (and possible prefix) used in MPD elements. Overrides auto-detected full scheme://host")
+	f.String("host", k.String("host"),
+		"full scheme://host used in MPD Location/BaseURL. "+
+			"If empty, auto-detected from the request (honors X-Forwarded-Proto)")
 	f.String("playurl", k.String("playurl"), "URL template to play mpd. %s will be replaced by MPD URL")
 	f.String("drmcfgfile", k.String("drmcfgfile"), "DRM config file path")
 

--- a/cmd/livesim2/app/configurl.go
+++ b/cmd/livesim2/app/configurl.go
@@ -507,7 +507,13 @@ func (c *ResponseConfig) URLContentPart() string {
 	return strings.Join(c.URLParts[c.URLContentIdx:], "/")
 }
 
-// fullHost uses non-empty cfgHost or extracts from requests scheme://host from request.
+// fullHost returns scheme://host for use in MPD elements.
+//
+// Precedence:
+//  1. cfgHost (operator override, expected to already include scheme).
+//  2. X-Forwarded-Proto header (set by a fronting proxy), if it carries
+//     a recognized scheme.
+//  3. r.TLS — https when the connection itself is TLS, otherwise http.
 func fullHost(cfgHost string, r *http.Request) string {
 	if cfgHost != "" {
 		return cfgHost
@@ -515,6 +521,16 @@ func fullHost(cfgHost string, r *http.Request) string {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
+	}
+	if xfp := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); xfp != "" {
+		// Some proxies send a comma-separated list; take the first entry.
+		if idx := strings.IndexByte(xfp, ','); idx >= 0 {
+			xfp = strings.TrimSpace(xfp[:idx])
+		}
+		switch strings.ToLower(xfp) {
+		case "http", "https":
+			scheme = strings.ToLower(xfp)
+		}
 	}
 	return fmt.Sprintf("%s://%s", scheme, r.Host)
 }

--- a/cmd/livesim2/app/configurl_test.go
+++ b/cmd/livesim2/app/configurl_test.go
@@ -5,6 +5,8 @@
 package app
 
 import (
+	"crypto/tls"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -313,6 +315,43 @@ func TestParseLossItvls(t *testing.T) {
 			gotItvls, err := CreateAllLossItvls(c.patter)
 			require.NoError(t, err)
 			require.Equal(t, c.wantedItvls, gotItvls)
+		})
+	}
+}
+
+func TestFullHost(t *testing.T) {
+	cases := []struct {
+		desc    string
+		cfgHost string
+		tls     bool
+		xfp     string
+		want    string
+	}{
+		{"cfgHost wins over everything", "https://override.example", true, "http", "https://override.example"},
+		{"cfgHost wins over XFP only", "https://override.example", false, "https", "https://override.example"},
+		{"plain http when no signals", "", false, "", "http://example.com"},
+		{"https when TLS terminates locally", "", true, "", "https://example.com"},
+		{"XFP=https sets https without local TLS", "", false, "https", "https://example.com"},
+		{"XFP=http overrides local TLS", "", true, "http", "http://example.com"},
+		{"XFP comma-list picks first entry", "", false, "https, http", "https://example.com"},
+		{"XFP case-insensitive", "", false, "HTTPS", "https://example.com"},
+		{"XFP with surrounding whitespace", "", false, "  https  ", "https://example.com"},
+		{"bogus XFP falls back to TLS detection", "", true, "ftp", "https://example.com"},
+		{"bogus XFP falls back to http when no TLS", "", false, "javascript", "http://example.com"},
+		{"empty XFP falls back to TLS detection", "", true, "", "https://example.com"},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			r, err := http.NewRequest("GET", "/", nil)
+			require.NoError(t, err)
+			r.Host = "example.com"
+			if c.tls {
+				r.TLS = &tls.ConnectionState{}
+			}
+			if c.xfp != "" {
+				r.Header.Set("X-Forwarded-Proto", c.xfp)
+			}
+			assert.Equal(t, c.want, fullHost(c.cfgHost, r))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- `fullHost()` now consults `X-Forwarded-Proto` between `--host` (still wins outright) and local `r.TLS` detection. Only `http` and `https` are accepted; whitespace is trimmed and a comma-separated chain falls back to the first hop. Unrecognized values fall through to TLS detection, so a malformed header can never break a `BaseURL`.
- The `--scheme` CLI flag has been removed. It was registered but never read by `ServerConfig` and had no effect; `--host=https://example.com` (or letting `X-Forwarded-Proto` come through from your proxy) is the supported way to set the scheme.
- New `TestFullHost` covers the precedence and sanitization rules.

## Motivation

When livesim2 is fronted by a TLS-terminating CDN or reverse proxy, the connection to livesim2 is plain HTTP, so `r.TLS` is nil and MPDs ended up advertising `http://` URLs even when the client used HTTPS. Honoring `X-Forwarded-Proto` (and dropping the no-op `--scheme` flag) fixes this without forcing operators to hard-code `--host`.

## Test plan

- [x] `go test ./cmd/livesim2/app/ -run TestFullHost` — 12 cases pass
- [x] `go test ./cmd/livesim2/...` — full suite green
- [x] `go build ./cmd/livesim2/` — clean
- [x] pre-commit (trim/whitespace, go fmt, golangci-lint, go-unit-tests) — all pass
- [ ] Manual: behind nginx with `proxy_set_header X-Forwarded-Proto $scheme;` at the TLS hop, confirm MPD `BaseURL` / `Location` show `https://`