### PR TITLE
chore: move project to Go 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         platform: [macos-latest, ubuntu-latest, windows-latest]
-        go-version: ["1.24"]
+        go-version: ["1.25"]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Go

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.24
+          go-version: 1.25
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the project to Go 1.25 (`go.mod`, GitHub Actions workflows, and the `Dockerfile` build stage).
+
 ### Added
 
 - Honor the `X-Forwarded-Proto` header (set by a fronting proxy / CDN) when constructing the scheme in MPD `Location` and `BaseURL` elements. Only `http` and `https` are accepted; other values fall back to local TLS detection.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Mount a volume with VoD Content at /vod to have livesim2 serve everything below it
 
 # Build Stage
-FROM golang:1.24-alpine3.21 AS BuildStage
+FROM golang:1.25-alpine3.22 AS BuildStage
 RUN apk add git
 WORKDIR /work
 COPY . .

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ the 1970 Epoch start, and makes it possible to test time-dependent requests in a
 
 ## Get Started
 
-Install Go 1.23 or later.
+Install Go 1.25 or later.
 
 Then run
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dash-Industry-Forum/livesim2
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/Comcast/gots/v2 v2.2.1


### PR DESCRIPTION
## Summary

Upgrades the whole project to Go 1.25, keeping `go.mod`, the GitHub Actions workflows, and the Docker build stage in sync.

This also fixes the class of failure that prevented the v1.9.0 Docker image from publishing: at that tag `go.mod` required `go 1.24.0` while the `Dockerfile` still pinned `golang:1.23.1`, so the alpine-based build failed and the image push was skipped. Keeping all version references aligned avoids a repeat.

## Changes

- `go.mod` — `go 1.24.0` → `go 1.25.0`
- `.github/workflows/go.yml` — build/test matrix `1.24` → `1.25`
- `.github/workflows/golangci-lint.yml` — setup-go `1.24` → `1.25`
- `Dockerfile` — build stage `golang:1.24-alpine3.21` → `golang:1.25-alpine3.22`
- `README.md` — "Install Go 1.23 or later" → 1.25
- `CHANGELOG.md` — added a `Changed` entry under `[Unreleased]`

## Testing

- `make test` — all packages pass
- `pre-commit run --all-files` — all hooks pass (trailing whitespace, go fmt, golangci-lint, go-unit-tests)