### PR TITLE
fix: default playurl to dash.js nightly instead of latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgraded the project to Go 1.25 (`go.mod`, GitHub Actions workflows, and the `Dockerfile` build stage).
+- Default `--playurl` reference player switched from `dash.js/latest` to `dash.js/nightly`,
+  since `latest` currently ignores the MPD URL parameters passed via `?mpd=`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ via the command line looks like:
   --logformat string     log format [text, json, pretty, discard] (default "text")
   --loglevel string      log level [DEBUG, INFO, WARN, ERROR] (default "INFO")
   --maxrequests int      max nr of request per IP address per 24 hours
-  --playurl string       URL template to play mpd. %s will be replaced by MPD URL (default "https://reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true")
+  --playurl string       URL template to play mpd. %s will be replaced by MPD URL (default "https://reference.dashif.org/dash.js/nightly/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true")
   --port int             HTTP port (default 8888)
   --repdataroot string   Representation metadata root directory. "+" copies vodroot value. "-" disables usage. (default "+")
   --reqlimitint int      interval for request limit i seconds (only used if maxrequests > 0) (default 86400)

--- a/cmd/livesim2/app/config.go
+++ b/cmd/livesim2/app/config.go
@@ -34,7 +34,7 @@ const (
 	defaultTimeSubsDurMS            = 900
 	defaultLatencyTargetMS          = uint32(3500)
 	//nolint:lll
-	defaultPlayURL = "https://reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true"
+	defaultPlayURL = "https://reference.dashif.org/dash.js/nightly/samples/dash-if-reference-player/index.html?mpd=%s&autoLoad=true&muted=true"
 )
 
 type ServerConfig struct {

--- a/cmd/livesim2/app/templates/welcome.html
+++ b/cmd/livesim2/app/templates/welcome.html
@@ -27,7 +27,7 @@
         The easiest way to configure the URLs to with such parameters is the <a href="{{.Host}}/urlgen">URL generator</a> page.
 
         Note, the URL generator and other pages include links for direct playback using online versions of
-        <a href="https://reference.dashif.org/dash.js/latest/samples/dash-if-reference-player/index.html">dash.js </a> or
+        <a href="https://reference.dashif.org/dash.js/nightly/samples/dash-if-reference-player/index.html">dash.js </a> or
         any other configured player. However, some restrictions may apply as discussed on the Wiki page
         <a href="https://github.com/Dash-Industry-Forum/livesim2/wiki/Direct-Playback">Direct Playback</a>.</p>
 


### PR DESCRIPTION
## Summary

The dash.js **`latest`** reference-player build currently ignores the MPD URL passed via
`?mpd=`, so the **Play** links livesim2 generates (on `/urlgen/` and the assets page) open the
player but don't load the stream. The **`nightly`** build honors the parameter.

This switches the default `--playurl` to point at `nightly` instead of `latest`.

## Changes

- `cmd/livesim2/app/config.go` — `defaultPlayURL` now uses `dash.js/nightly`.
- `cmd/livesim2/app/templates/welcome.html` — the reference-player link on the landing page updated to match.
- `README.md` — the documented `--playurl` default updated.
- `CHANGELOG.md` — entry under *Changed*.

The value is still overridable via `--playurl` / the `playurl` config key / `LIVESIM_PLAYURL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
