### PR TITLE
release: v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.10.0] - 2026-06-15
+
 ### Changed
 
 - Upgraded the project to Go 1.25 (`go.mod`, GitHub Actions workflows, and the `Dockerfile` build stage).
@@ -410,7 +414,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.6.0...v1.7.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.9.0"     // Should be updated during build
-	commitDate    string = "1770277089" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.10.0"    // Should be updated during build
+	commitDate    string = "1781474400" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
## Summary

- Bumps version to `v1.10.0` (2026-06-15)
- Moves Unreleased changelog entries to `[1.10.0]` section
- Adds `[1.10.0]` compare link in the changelog footer

## Test plan

- [x] Verify `GetVersion()` returns `v1.10.0, date: 2026-06-15`
- [x] Confirm CHANGELOG.md links resolve correctly on GitHub