### PR TITLE
feat(urlgen): disable DRM options for pre-encrypted assets via htmx OOB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Changed
+
+- URL generator: DRM options now follow the selected asset and are disabled for pre-encrypted assets.
 
 ## [1.10.0] - 2026-06-15
 

--- a/cmd/livesim2/app/handler_urlgen.go
+++ b/cmd/livesim2/app/handler_urlgen.go
@@ -68,23 +68,19 @@ func (s *Server) urlGenHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	var data urlGenData
 	switch r.URL.Path {
 	case "/urlgen/mpds":
+		// Changing the asset updates two regions of the page from a single response: the MPD
+		// <select> (the primary hx-target) and the DRM options (an out-of-band swap into #drms).
+		// The DRM choices are asset-dependent: a pre-encrypted asset offers no DRM choice at all.
+		// See the "assetopts" template in urlgen.html.
 		asset := r.URL.Query().Get("asset")
 		for _, a := range aInfo.Assets {
 			if a.Path == asset {
 				data.MPDs = mpdsFromAssetInfo(a)
 				data.MPDs[0].Selected = true
+				data.DRMs = drmsFromAssetInfo(a, s.Cfg.DrmCfg, "")
 			}
 		}
-		templateName = "mpds"
-	case "/urlgen/drms":
-		asset := r.URL.Query().Get("asset")
-		for _, aI := range aInfo.Assets {
-			if aI.Path == asset {
-				data.DRMs = drmsFromAssetInfo(aI, s.Cfg.DrmCfg, "")
-				data.DRMs[0].Selected = true
-			}
-		}
-		templateName = "drms"
+		templateName = "assetopts"
 	case "/urlgen/create":
 		data = createURL(r, aInfo, s.Cfg.DrmCfg)
 	default:
@@ -114,7 +110,7 @@ func drmsFromAssetInfo(a *assetInfo, drmCfg *drm.DrmConfig, selected string) []n
 	}
 	drmPkgs := drmCfg.Packages
 	if a != nil && a.PreEncrypted {
-		return []nameWithSelect{{Name: "None", Selected: true,
+		return []nameWithSelect{{Name: "None", Selected: true, Disabled: true,
 			Desc: fmt.Sprintf("No DRM choice available because asset %q is pre-encrypted", a.Path)}}
 	}
 	drms := make([]nameWithSelect, 0, 3+len(drmPkgs))
@@ -196,6 +192,7 @@ type nameWithSelect struct {
 	Name     string
 	Desc     string
 	Selected bool
+	Disabled bool // render the option as disabled (e.g. DRM choices for a pre-encrypted asset)
 }
 
 type segmentTimelineType string

--- a/cmd/livesim2/app/handler_urlgen_test.go
+++ b/cmd/livesim2/app/handler_urlgen_test.go
@@ -6,11 +6,15 @@ package app
 
 import (
 	"bytes"
+	"context"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/Dash-Industry-Forum/livesim2/pkg/drm"
+	"github.com/Dash-Industry-Forum/livesim2/pkg/logging"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,4 +105,69 @@ func TestURLGenTemplateRendersSGAI(t *testing.T) {
 	require.Contains(t, out, `name="sgaiInterests"`)
 	require.Contains(t, out, "value=\"30:15\"")
 	require.Contains(t, out, "value=\"alice\"")
+}
+
+// TestURLGenAssetOptsOOB confirms that the "assetopts" template (served when the asset <select>
+// changes) updates two regions from one response: the MPD options for #mpd and, via an htmx
+// out-of-band swap, the DRM options for #drms. A pre-encrypted asset must disable the DRM choice;
+// a clear asset must offer the full DRM list.
+func TestURLGenAssetOptsOOB(t *testing.T) {
+	tmpls, err := compileHTMLTemplates(content, "templates")
+	require.NoError(t, err)
+	drmCfg := &drm.DrmConfig{Packages: []*drm.Package{{Name: "cbcs-all", Desc: "cbcs all tracks"}}}
+
+	render := func(a *assetInfo) string {
+		data := urlGenData{
+			MPDs: []nameWithSelect{{Name: "stream.mpd", Selected: true}},
+			DRMs: drmsFromAssetInfo(a, drmCfg, ""),
+		}
+		var buf bytes.Buffer
+		require.NoError(t, tmpls.ExecuteTemplate(&buf, "assetopts", data))
+		return buf.String()
+	}
+
+	// Pre-encrypted: the DRM options collapse to a single disabled "None" with an explanation,
+	// and none of the real DRM choices are offered.
+	preEnc := render(&assetInfo{Path: "encrypted/asset", PreEncrypted: true})
+	require.Contains(t, preEnc, `value="stream.mpd"`, "MPD option must be present for #mpd")
+	require.Contains(t, preEnc, `hx-swap-oob="innerHTML"`, "DRM block must be an out-of-band swap")
+	require.Contains(t, preEnc, `id="drms"`, "OOB element must target #drms")
+	require.Contains(t, preEnc, "pre-encrypted", "must explain why DRM is unavailable")
+	require.Contains(t, preEnc, "disabled", "the lone DRM choice must be disabled")
+	require.NotContains(t, preEnc, `value="eccp-cbcs"`, "no DRM choices for a pre-encrypted asset")
+	require.NotContains(t, preEnc, `value="cbcs-all"`, "no commercial DRM for a pre-encrypted asset")
+
+	// Clear asset: the full DRM list is offered and nothing is disabled.
+	clear := render(&assetInfo{Path: "clear/asset", PreEncrypted: false})
+	require.Contains(t, clear, `hx-swap-oob="innerHTML"`, "DRM block must still be an out-of-band swap")
+	require.Contains(t, clear, `value="eccp-cbcs"`)
+	require.Contains(t, clear, `value="eccp-cenc"`)
+	require.Contains(t, clear, `value="cbcs-all"`)
+	require.NotContains(t, clear, "disabled", "no DRM choice should be disabled for a clear asset")
+}
+
+// TestURLGenMpdsEndpointUpdatesDRMsOOB drives the /urlgen/mpds endpoint over HTTP and confirms a
+// single response updates two regions: the MPD <select> (#mpd) and, out-of-band, the DRM options
+// (#drms). This is the wiring that lets the DRM choices follow the selected asset.
+func TestURLGenMpdsEndpointUpdatesDRMsOOB(t *testing.T) {
+	drmCfg, err := drm.ReadDrmConfig("testdata/drm.json")
+	require.NoError(t, err)
+	cfg := ServerConfig{
+		VodRoot:   "testdata/assets",
+		TimeoutS:  0,
+		LogFormat: logging.LogDiscard,
+		DrmCfg:    drmCfg,
+	}
+	require.NoError(t, logging.InitSlog(cfg.LogLevel, cfg.LogFormat))
+	server, err := SetupServer(context.Background(), &cfg)
+	require.NoError(t, err)
+	ts := httptest.NewServer(server.Router)
+	defer ts.Close()
+
+	resp, body := testFullRequest(t, ts, "GET", "/urlgen/mpds?asset=testpic_2s", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	out := string(body)
+	require.Contains(t, out, "Manifest.mpd", "MPD options for #mpd must be present")
+	require.Contains(t, out, `id="drms" hx-swap-oob="innerHTML"`, "DRM block must be an out-of-band swap into #drms")
+	require.Contains(t, out, `value="eccp-cbcs"`, "a clear asset must still offer the DRM choices")
 }

--- a/cmd/livesim2/app/templates/urlgen.html
+++ b/cmd/livesim2/app/templates/urlgen.html
@@ -238,12 +238,13 @@
 			<summary>Encryption and DRM</summary>
 			<fieldset>
 				<legend>Encryption on-the-fly with keys via ECCP or commercial DRM systems. Pre-encrypted assets cannot be changed.</legend>
-				<!-- This should be asset dependent, but not got the right htmx to do that yet -->
+				<!-- Asset-dependent: refreshed via an htmx out-of-band swap whenever the asset
+				     changes (see the "assetopts" template). A pre-encrypted asset offers no DRM choice. -->
 				 <div name="drms" id="drms">
 				{{block "drms" .}}
 				{{range .DRMs}}
 				<label for="drm-{{.Name}}">
-					<input type="radio" id="drm-{{.Name}}" name="drm" value="{{.Name}}" {{if .Selected}} checked {{end}}>
+					<input type="radio" id="drm-{{.Name}}" name="drm" value="{{.Name}}" {{if .Selected}} checked {{end}}{{if .Disabled}} disabled {{end}}>
 					{{.Desc}}
 				</label>
 			    {{end}}
@@ -396,3 +397,15 @@
 		</main>
     </body>
 </html>
+
+{{/*
+  assetopts is the response served when the asset <select> changes. A single response updates
+  two distinct regions of the page: the MPD <select> (the primary hx-target #mpd) gets the MPD
+  options, and the DRM radio buttons are refreshed via an htmx out-of-band swap into #drms.
+  This is how the (asset-dependent) DRM choices follow the selected asset — in particular a
+  pre-encrypted asset collapses to a single, disabled "None" choice.
+*/}}
+{{define "assetopts" -}}
+{{template "mpds" .}}
+<div id="drms" hx-swap-oob="innerHTML">{{template "drms" .}}</div>
+{{- end}}

--- a/cmd/livesim2/app/templates_test.go
+++ b/cmd/livesim2/app/templates_test.go
@@ -78,7 +78,9 @@ func TestHTMLTemplates(t *testing.T) {
 	require.NoError(t, err)
 	welcomeStr := buf.String()
 	require.Greater(t, strings.Index(welcomeStr, `href="http://localhost:8888/assets"`), 0)
-	require.Equal(t, 7, len(textTemplates.Templates()))
+	// In addition to the .html files, urlgen.html defines the "mpds", "drms" and "assetopts"
+	// named templates, so the count exceeds the number of template files.
+	require.Equal(t, 8, len(textTemplates.Templates()))
 
 	// The SGAI status page is a template that loads its polling logic from a static asset and
 	// carries the host for proxy/base-path setups; both must be interpolated with the host.


### PR DESCRIPTION
## Summary

The URL generator's DRM options now follow the selected asset. Previously, changing
the asset only updated the MPD list; the DRM section stayed stale (the
`<!-- ...not got the right htmx to do that yet -->` placeholder). A pre-encrypted asset
cannot have DRM added on the fly, so its DRM choices are now disabled.

## What changed

- Changing the asset `<select>` now updates **two regions from a single response** via an
  htmx **out-of-band (OOB) swap**: the MPD `<select>` (`#mpd`, the primary target) and the
  DRM radios (`#drms`). The bundled htmx is already 2.0.0, which supports OOB — no upgrade needed.
- `/urlgen/mpds` now populates both MPDs and DRMs and renders a new `assetopts` template;
  the redundant `/urlgen/drms` endpoint (nothing called it) is removed.
- Pre-encrypted assets render a single, **disabled** "None" choice with an explanation
  (new `Disabled` field on `nameWithSelect`).

## Tests

- `TestURLGenAssetOptsOOB` — the `assetopts` template emits the OOB `#drms` swap, a disabled
  "None" + explanation for pre-encrypted assets, and the full DRM list for clear assets.
- `TestURLGenMpdsEndpointUpdatesDRMsOOB` — end-to-end HTTP check that `/urlgen/mpds` returns
  both the MPD options and the OOB `#drms` div.
- Updated the template-count assertion in `TestHTMLTemplates` (7 → 8).
- `go test ./cmd/livesim2/app/` and `golangci-lint` both pass.

## Note

The DRM section only appears when a DRM config is loaded (`--drmcfgfile`); that is pre-existing
behavior and is unchanged.
