### PR TITLE
fix(sgai): prevent attribute XSS in session-status page (complete esc)

### DIFF
--- a/cmd/livesim2/app/static/sgai_session_status.js
+++ b/cmd/livesim2/app/static/sgai_session_status.js
@@ -32,8 +32,10 @@
     refresh();
   });
 
-  const esc = (s) => String(s == null ? '' : s).replace(/[&<>]/g,
-    (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+  // Escape for both HTML text and double-/single-quoted attribute contexts (esc() output is used in
+  // both, e.g. <tr class="..."), so a value can never break out of an attribute.
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g,
+    (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
   const fmtTime = (t) => { try { return new Date(t).toLocaleTimeString(); } catch (e) { return t; } };
 
   function renderSession(s) {


### PR DESCRIPTION
The `esc()` helper in `static/sgai_session_status.js` escaped only `& < >`, but its output is interpolated into a double-quoted HTML attribute (`<tr class="$esc(e.kind)">`), so a value containing a quote could break out of the attribute (incomplete HTML attribute sanitization / XSS).

Fix: also escape `"` and `'` so `esc()` is safe in both text and attribute contexts.

This is the same hardening applied to the content-steering status page after CodeQL flagged it there (PR #306); this fixes the pre-existing instance in the SGAI page on `main`. In practice values are server-side constrained, so it's defense-in-depth, but it also clears the scanner.

Static asset only — no Go changes.