### PR TITLE
elease): v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.11.0] - 2026-06-30
+
 ### Added
 
 - DASH Content Steering (ISO/IEC 23009-1 6th ed. §K.3.6, ETSI TS 103 998): the `steer_` URL option
@@ -18,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`_DASH_pathway`/`_DASH_throughput`) are verified and off-pathway clients flagged. An optional
   `csid_<group>` token groups sessions under one shared decision. The `/urlgen/` form has a Content
   Steering section and the index page links to the monitor.
-
 - DASH XLink for multi-period: the `xlink_1` URL option activates the replacement of completed past
   periods elements with remote elements using XLink elements with `xlink:href="onRequest"`.
   The XLink urls for each completed period target the same endpoint as the manifest and adding the
@@ -40,11 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `templ generate` (see `make templ`); a `make templ-check` target and a pre-commit
   hook (triggered by both `*.templ` and `*_templ.go` changes) keep the generated code in
   sync, and the generated `*_templ.go` files are excluded from `golangci-lint`.
+- Updated `github.com/go-chi/chi/v5` from v5.2.2 to v5.2.4.
 
 ### Fixed
 
 - cmaf-ingest-receiver tests: replaced fixed `time.Sleep` waits for the receiver's asynchronous
   writes with polling (`EventuallyWithT`), fixing intermittent failures on the Windows CI runner.
+- Hardened the `esc()` helper on the SGAI session-status page (added in v1.10.0) to also escape
+  `"` and `'`, so values interpolated into double-quoted HTML attributes cannot break out of the
+  attribute (attribute XSS); matches the same hardening on the content-steering status page.
 
 ## [1.10.0] - 2026-06-15
 
@@ -451,7 +458,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.7.0...v1.8.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.10.0"    // Should be updated during build
-	commitDate    string = "1781474400" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.11.0"    // Should be updated during build
+	commitDate    string = "1782770400" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
### Added

- DASH Content Steering (ISO/IEC 23009-1 6th ed. §K.3.6, ETSI TS 103 998): the `steer_` URL option
  advertises several service locations ("CDNs") that point back to this server and adds a
  `<ContentSteering>` element; the steering endpoint returns a `PATHWAY-PRIORITY` manifest with a
  configurable `ttl=` and `mode=trigger` (hold until switched) or `mode=rotate`. Per-session,
  per-CDN segment requests are tracked and switchable via the `/api/steering/…` API and a live
  `/steering/session_status` monitor page; client steering messages
  (`_DASH_pathway`/`_DASH_throughput`) are verified and off-pathway clients flagged. An optional
  `csid_<group>` token groups sessions under one shared decision. The `/urlgen/` form has a Content
  Steering section and the index page links to the monitor.
- DASH XLink for multi-period: the `xlink_1` URL option activates the replacement of completed past
  periods elements with remote elements using XLink elements with `xlink:href="onRequest"`.
  The XLink urls for each completed period target the same endpoint as the manifest and adding the
  `?period=<period_id>` query parameter, which is interpreted by livesim2 to return the corresponding Period element.

### Changed

- URL generator: DRM options now follow the selected asset and are disabled for pre-encrypted assets.
- The SGAI and Content Steering live monitor pages (`/sgai/session_status`,
  `/steering/session_status`) now follow the system light/dark setting (via Pico CSS) like the
  other web pages, with theme-aware status colours for legibility on both backgrounds, while
  staying full-width and compact for their denser tables. Their shared styles and JS helpers
  (`esc`/`fmtTime`/`setDot`) are factored into `static/session_status.css` and
  `static/session_status_common.js`.
- Migrated the HTML web pages (welcome, assets, VoD assets, URL generator, SGAI
  session status) from Go's `html/template` to type-safe [templ](https://templ.guide)
  components (`*.templ` → generated `*_templ.go`). The `text/template` XML subtitle
  templates (`stpptime.xml`, `stpptimecue.xml`) are unchanged. Building now runs
  `templ generate` (see `make templ`); a `make templ-check` target and a pre-commit
  hook (triggered by both `*.templ` and `*_templ.go` changes) keep the generated code in
  sync, and the generated `*_templ.go` files are excluded from `golangci-lint`.
- Updated `github.com/go-chi/chi/v5` from v5.2.2 to v5.2.4.

### Fixed

- cmaf-ingest-receiver tests: replaced fixed `time.Sleep` waits for the receiver's asynchronous
  writes with polling (`EventuallyWithT`), fixing intermittent failures on the Windows CI runner.
- Hardened the `esc()` helper on the SGAI session-status page (added in v1.10.0) to also escape
  `"` and `'`, so values interpolated into double-quoted HTML attributes cannot break out of the
  attribute (attribute XSS); matches the same hardening on the content-steering status page.