### PR TITLE
fix(cc608): flip each caption on its cue's first frame, with a -sc opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- In-band CTA-608 captions (`timecc608`) are now displayed over exactly the interval their text names.
-  A pop-on caption needs a build (written into non-displayed memory) and an EOC that flips it on screen,
-  and both drain at one 608 pair per frame. The build used to start at its own cue's first frame, which
-  put the flip 15-20 frames — 0.6-0.75 s of a one-second cue — *after* the time the caption displays.
-  Each cue's EOC now rides its cue's first frame with the build transmitted over the preceding frames, so
-  the flip coincides with the cue boundary. Captions consequently span segment boundaries: a segment
-  carries the build for the first cue of whatever follows it, so a client that starts or seeks mid-stream
-  gets a leading EOC without its build, shows no caption for that first cue period, and is correct from
-  the next cue on. The 608 data rate is unchanged at one pair per frame.
+- In-band CTA-608 captions (`timecc608`) are now displayed over exactly the interval their text names,
+  instead of appearing 0.6-0.75 s into it. Each cue's pop-on flip rides its cue's first frame, with the
+  build sent over the preceding frames. Captions consequently span segment boundaries, which costs a
+  client that starts or seeks mid-stream its first cue period — see the [README](README.md).
 
 ## [1.12.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - mp4ff dependency bumped to v0.55.0 and go-608 to v0.7.0
 
+### Fixed
+
+- In-band CTA-608 captions (`timecc608`) are now displayed over exactly the interval their text names.
+  A pop-on caption needs a build (written into non-displayed memory) and an EOC that flips it on screen,
+  and both drain at one 608 pair per frame. The build used to start at its own cue's first frame, which
+  put the flip 15-20 frames — 0.6-0.75 s of a one-second cue — *after* the time the caption displays.
+  Each cue's EOC now rides its cue's first frame with the build transmitted over the preceding frames, so
+  the flip coincides with the cue boundary. Captions consequently span segment boundaries: a segment
+  carries the build for the first cue of whatever follows it, so a client that starts or seeks mid-stream
+  gets a leading EOC without its build, shows no caption for that first cue period, and is correct from
+  the next cue on. The 608 data rate is unchanged at one pair per frame.
+
 ## [1.12.0] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional `-sc` field on `timecc608` (e.g. `timecc608_CC1-eng-sc`) keeps every CTA-608 caption inside the
+  segment that carries it, so segments stay independently decodable for a client that starts, seeks or joins
+  mid-stream. In exchange each caption appears ~0.5 s into the second its clock names, which is the behaviour
+  from before the flip-on-cue-start fix below.
+
 ### Changed
 
 - mp4ff dependency bumped to v0.55.0 and go-608 to v0.7.0

--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ belongs to it, and what it shows for that first cue period depends on its decode
 608 decoder has nothing loaded and shows **no caption**, while one that keeps 608 state
 across the discontinuity flips whatever was last preloaded and can show **one cue of a
 stale caption**. Either way it corrects at the next cue boundary, typically within a
-second. The server cannot avoid this — any pair sent ahead of the `EOC` to clear the
-state would erase the build that is about to be flipped.
+second.
+
+This is a receiver-side matter, not something the server can paper over: any pair sent
+ahead of the `EOC` to clear the state would erase the build that is about to be flipped.
+A player should reset its 608 decoder state on a seek or other discontinuity — which is
+what turns the stale case into the blank one — exactly as it resets any other decoder.
 
 The new `livesim2` software is written in Go instead of Python and designed to handle
 content in a more flexible and versatile way. It is intended to be very easy to install and deploy locally

--- a/README.md
+++ b/README.md
@@ -36,6 +36,24 @@ channel CC1, and advertises it with a CEA-608 `Accessibility` descriptor. The va
 `<channel>-<lang>` (only `CC1` is supported so far). It cannot be combined with encryption
 and is rejected for assets that already carry captions.
 
+Each caption is displayed over exactly the interval its text names. A pop-on caption is
+two transmissions — a build written into the receiver's non-displayed memory, and an `EOC`
+that flips it on screen — and both drain at one 608 byte pair per frame. The flip rides the
+first frame of its cue, and the ~15-19 pair build is sent over the frames *before* it,
+which for a segment's first cue means the **previous segment**; each segment likewise
+carries the build for the first cue of the segment that follows it. Segments are still
+generated independently and on demand, since both sides derive that shared cue from the
+same wall-clock time and segment number.
+
+The trade-off is that captions are no longer self-contained per segment. A client that
+starts, seeks, or joins mid-stream gets a segment's leading `EOC` without the build that
+belongs to it, and what it shows for that first cue period depends on its decoder: a fresh
+608 decoder has nothing loaded and shows **no caption**, while one that keeps 608 state
+across the discontinuity flips whatever was last preloaded and can show **one cue of a
+stale caption**. Either way it corrects at the next cue boundary, typically within a
+second. The server cannot avoid this — any pair sent ahead of the `EOC` to clear the
+state would erase the build that is about to be flipped.
+
 The new `livesim2` software is written in Go instead of Python and designed to handle
 content in a more flexible and versatile way. It is intended to be very easy to install and deploy locally
 since it is compiled into a single binary that serves the content via a built-in

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There is a corresponding setting for `wvtt` (segmented WebVTT) subtitles using `
 For in-band closed captions, `/timecc608_CC1-eng` injects a CTA-608 (CEA-608) caption
 into the AVC/HEVC video itself, showing a ticking UTC clock and the segment number on
 channel CC1, and advertises it with a CEA-608 `Accessibility` descriptor. The value is
-`<channel>-<lang>` (only `CC1` is supported so far). It cannot be combined with encryption
+`<channel>-<lang>[-sc]` (only `CC1` is supported so far). It cannot be combined with encryption
 and is rejected for assets that already carry captions.
 
 Each caption is displayed over exactly the interval its text names. A pop-on caption is
@@ -57,6 +57,14 @@ This is a receiver-side matter, not something the server can paper over: any pai
 ahead of the `EOC` to clear the state would erase the build that is about to be flipped.
 A player should reset its 608 decoder state on a seek or other discontinuity — which is
 what turns the stale case into the blank one — exactly as it resets any other decoder.
+
+Appending `-sc` (`/timecc608_CC1-eng-sc`) switches this trade the other way: a cue's build
+and its flip both ride the cue's own frames, so every caption stays inside the segment that
+carries it and no segment depends on its neighbour. A client can then start, seek or join
+anywhere and see a complete caption immediately. The cost is latency — the flip can only
+follow its own build, so each caption appears ~0.5 s into the second its clock names and
+remains up into the next one. Use the default for frame-accurate timing, `-sc` to test a
+player against captions that are decodable segment by segment.
 
 The new `livesim2` software is written in Go instead of Python and designed to handle
 content in a more flexible and versatile way. It is intended to be very easy to install and deploy locally

--- a/cmd/livesim2/app/cc608.go
+++ b/cmd/livesim2/app/cc608.go
@@ -22,7 +22,18 @@ type CC608Config struct {
 	// Lang is the RFC-5646 language code used both for the caption content locale
 	// and for the value of the MPD Accessibility descriptor.
 	Lang string `json:"Lang"`
+	// SelfContained keeps every caption inside the segment that carries it: a cue's
+	// pop-on build and its EOC flip both ride the cue's own frames, so no segment
+	// depends on its neighbour. The flip then lands ~build-pairs frames into the cue
+	// (0.6-0.75 s of a one-second cue), so the caption lags the interval its text
+	// names. The default (false) flips each caption on its cue's first frame instead,
+	// which is frame-accurate but makes a caption span the segment boundary.
+	SelfContained bool `json:"SelfContained,omitempty"`
 }
+
+// cc608SelfContainedToken is the optional trailing field of the timecc608 value that
+// asks for self-contained segments.
+const cc608SelfContainedToken = "sc"
 
 // cc608LangRegexp is a light RFC-5646 check: a 2-3 letter primary subtag followed by
 // optional hyphen-separated subtags (e.g. eng, swe, en-US, zh-Hans).
@@ -30,21 +41,42 @@ var cc608LangRegexp = regexp.MustCompile(`^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$`)
 
 // CreateCC608Config parses the value of a "timecc608" URL option.
 //
-// Grammar: <channel>-<lang>, e.g. CC1-eng.
+// Grammar: <channel>-<lang>[-sc], e.g. CC1-eng or CC1-eng-sc.
 //   - channel: CEA-608 channel; only CC1 is supported in the first milestone.
 //   - lang:    RFC-5646 language code (caption locale + MPD Accessibility value).
+//   - sc:      optional; keep captions self-contained per segment (see
+//     CC608Config.SelfContained). Omitted, captions flip on their cue's first frame.
+//
+// Since a language tag may itself carry hyphenated subtags (en-US, zh-Hans), the "sc"
+// field is only recognized as such when the value has three or more fields; the lang is
+// everything between the channel and it. "CC1-sc" is therefore the language "sc"
+// (Sardinian), and "CC1-sc-sc" is that language with self-contained segments. The one
+// tag this cannot express is a language whose final subtag is literally "sc".
 func CreateCC608Config(val string) (*CC608Config, error) {
-	channel, lang, ok := strings.Cut(val, "-")
+	channel, rest, ok := strings.Cut(val, "-")
 	if !ok {
-		return nil, fmt.Errorf("timecc608 must be <channel>-<lang>, got %q", val)
+		return nil, fmt.Errorf("timecc608 must be <channel>-<lang>[-sc], got %q", val)
 	}
 	if channel != "CC1" {
 		return nil, fmt.Errorf("timecc608 channel %q not supported (only CC1)", channel)
 	}
+	lang := rest
+	selfContained := false
+	if pre, last, hasMore := cutLast(rest, "-"); hasMore && last == cc608SelfContainedToken {
+		lang, selfContained = pre, true
+	}
 	if !cc608LangRegexp.MatchString(lang) {
 		return nil, fmt.Errorf("timecc608 language %q is not a valid RFC-5646 code", lang)
 	}
-	return &CC608Config{Channel: channel, Lang: lang}, nil
+	return &CC608Config{Channel: channel, Lang: lang, SelfContained: selfContained}, nil
+}
+
+// cutLast splits s around the last instance of sep, like strings.Cut around the first.
+func cutLast(s, sep string) (before, after string, found bool) {
+	if i := strings.LastIndex(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, "", false
 }
 
 // ParseCC608Config parses a "timecc608" option value, accumulating any error.

--- a/cmd/livesim2/app/cc608_inject.go
+++ b/cmd/livesim2/app/cc608_inject.go
@@ -7,6 +7,7 @@ package app
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/Eyevinn/go-608/carriage"
 	"github.com/Eyevinn/go-608/cta608"
 	"github.com/Eyevinn/go-608/generate"
+	"github.com/Eyevinn/go-608/schedule"
 	"github.com/Eyevinn/mp4ff/avc"
 	"github.com/Eyevinn/mp4ff/hevc"
 	"github.com/Eyevinn/mp4ff/mp4"
@@ -47,8 +49,8 @@ func cc608CodecFor(codecs string) (carriage.Codec, bool) {
 // cc608CueContent formats one cue for a segment: line 1 is the cue's UTC time
 // (millisecond precision, so it stays accurate for non-integer-second segments),
 // line 2 is "SEG <nr>" held constant across the segment's cues. The caller closes
-// over segNr; keeping the content a pure function of (cueIdx, cueStartMS) makes a
-// segment's captions independent of any other segment.
+// over segNr; keeping the content a pure function of (cueIdx, cueStartMS) is what
+// lets a segment build the *next* segment's first cue without shared state.
 func cc608CueContent(segNr uint32) generate.CueContentFunc {
 	return func(cueIdx int, cueStartMS int64) generate.UnitCue {
 		ts := time.UnixMilli(cueStartMS).UTC().Format("15:04:05.000")
@@ -60,26 +62,135 @@ func cc608CueContent(segNr uint32) generate.CueContentFunc {
 	}
 }
 
-// injectCC608 splices in-band CTA-608 caption SEI into a segment's video samples
-// in place. It builds one self-contained per-segment caption (a UTC clock + the
-// segment number, updated ~every second) via go-608 BuildUnitCues, then inserts
-// the resulting per-frame SEI NALU before the first VCL NALU of each sample,
-// updating Data and Size. samples are the video track's FullSamples in decode
-// order; fps and unitStartMS give the caption timing; segNr is the segment number.
+// cc608SplitEOC separates the terminating EOC command (the pop-on flip) from the
+// build tokens, so the build can be transmitted ahead of the flip. A non-pop-on or
+// empty sequence yields a nil eoc.
+func cc608SplitEOC(toks []cta608.Token) (build, eoc []cta608.Token) {
+	if n := len(toks); n > 0 {
+		if c, ok := toks[n-1].(cta608.Command); ok && c.Op == cta608.EOC {
+			return toks[:n-1], toks[n-1:]
+		}
+	}
+	return toks, nil
+}
+
+// cc608PairCount returns the number of field-1 byte pairs a token sequence
+// serializes to, i.e. how many frames it takes to drain at one pair per frame.
+func cc608PairCount(toks []cta608.Token) int {
+	if len(toks) == 0 {
+		return 0
+	}
+	return len(cta608.Serialize(toks, cta608.SerializeOptions{
+		Field: 1, Channel: 1, Doubling: cta608.DoublingOff,
+	})) / 2
+}
+
+// cc608UnitFrames builds the per-frame CTA-608 schedule for one unit (one fragment)
+// of nFrames frames starting at unitStartMS.
 //
-// BuildUnitCues yields a presentation-ordered per-frame schedule, but samples
-// arrive in decode order. Since receivers reassemble cc_data by presentation time
-// (PTS) — dash.js, hls.js and Shaka all sort caption pairs by PTS — the k-th
-// caption frame must ride the k-th sample in *presentation* order. With B-frames
-// (decode order != presentation order) a naive frames[i]->samples[i] mapping
-// permutes the CEA-608 byte stream and garbles the caption.
-func injectCC608(samples []mp4.FullSample, fps float64, unitStartMS int64, segNr uint32, codec carriage.Codec) error {
+// A pop-on caption occupies two transmissions: a build (RCL + ENM + rows) written
+// into non-displayed memory, and an EOC that flips it on screen. Both drain at one
+// 608 pair per frame, so where the build is placed decides when the caption
+// appears. go-608's generate.BuildUnitCues starts the build at its cue's first
+// frame, which puts the flip ~pairs frames *into* the cue — ~0.5-0.75s of a
+// one-second cue — so the caption became visible well after the time it displays.
+//
+// Here each cue's EOC rides its cue's first frame and its build drains over the
+// frames immediately before it, so the flip coincides with the cue boundary and the
+// caption is shown exactly over the interval its text names. The consequence is that
+// a cue's build lives in the preceding cue's frames: the first cue's build belongs to
+// the *previous* unit, and this unit's tail carries the build for the next unit's
+// first cue (nextContent). Captions therefore span unit boundaries — a receiver
+// starting mid-stream gets the first EOC without its build and shows no caption for
+// one cue period, then is correct.
+//
+// Each cue is encoded with a fresh cta608.Encoder so its build is always a complete
+// rebuild. That keeps every EOC paired with a build that fully describes its screen,
+// which is what makes independently generated, on-demand units line up: the build in
+// unit N's tail and the flip at unit N+1's first frame are produced by separate
+// calls and must agree without sharing encoder state.
+func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextContent generate.CueContentFunc) ([]schedule.Frame, error) {
+	if nFrames <= 0 {
+		return nil, fmt.Errorf("cc608: nFrames must be > 0, got %d", nFrames)
+	}
+	if cc := int(math.Round(600.0 / fps)); cc < 2 || cc > 31 {
+		return nil, fmt.Errorf("cc608: fps %.3f yields cc_count %d outside 2..31", fps, cc)
+	}
+	frameDurMS := 1000.0 / fps
+	unitDurMS := int64(math.Round(float64(nFrames) * frameDurMS))
+	n := generate.NumCues(unitDurMS, cc608TargetPeriodMS)
+
+	wallAt := func(i int) int64 { return unitStartMS + int64(math.Round(float64(i)*frameDurMS)) }
+	// boundary(k) is the first unit-relative frame of cue k; boundary(n) == nFrames.
+	boundary := func(k int) int { return int(math.Round(float64(k) * float64(nFrames) / float64(n))) }
+
+	// Cue k flips at boundary(k). The extra entry at nFrames is the next unit's first
+	// cue: its build drains this unit's tail, its EOC belongs to the next unit.
+	type flip struct {
+		frame int
+		cue   generate.UnitCue
+	}
+	flips := make([]flip, 0, n+1)
+	for k := 0; k < n; k++ {
+		flips = append(flips, flip{boundary(k), content(k, wallAt(boundary(k)))})
+	}
+	flips = append(flips, flip{nFrames, nextContent(0, wallAt(nFrames))})
+
+	sched := schedule.NewScheduler(fps, schedule.WithDoubling(cta608.DoublingOff))
+	prevFlip := -1 // last frame already claimed by a flip
+	for i, f := range flips {
+		var enc cta608.Encoder
+		build, eoc := cc608SplitEOC(enc.Apply(cta608.CaptionBlock{Lines: f.cue.Lines, Mode: cta608.PopOn}))
+		buildStart := f.frame - cc608PairCount(build)
+		// The first cue flips at frame 0, so its build was transmitted by the previous
+		// unit and there is nothing to place here. Every other build must fit between
+		// the previous flip and this one — a build that does not fit would leave an EOC
+		// with nothing loaded, i.e. a caption that never appears.
+		if i > 0 && len(build) > 0 {
+			if buildStart <= prevFlip {
+				free := f.frame - prevFlip - 1
+				return nil, fmt.Errorf("cc608: cue flipping at frame %d needs %d frames of build but only %d are free "+
+					"at %g fps; shorten the lines or lower the update rate", f.frame, f.frame-buildStart, free, fps)
+			}
+			// Pushes drain in push order (the scheduler is a FIFO gated by eligibility
+			// time), so pushing the build before its EOC keeps the byte stream ordered
+			// and lands the flip on f.frame exactly.
+			sched.Push(schedule.TimedTokens{TimeMS: wallAt(buildStart), Field: 1, Tokens: build})
+		}
+		if f.frame < nFrames && len(eoc) > 0 {
+			sched.Push(schedule.TimedTokens{TimeMS: wallAt(f.frame), Field: 1, Tokens: eoc})
+		}
+		prevFlip = f.frame
+	}
+
+	frames := make([]schedule.Frame, nFrames)
+	for i := range frames {
+		frames[i] = sched.Frame(wallAt(i))
+	}
+	return frames, nil
+}
+
+// injectCC608 splices in-band CTA-608 caption SEI into a unit's video samples in
+// place. It builds the per-frame caption schedule (a UTC clock + the segment number,
+// updated ~every second) with cc608UnitFrames, then inserts the resulting per-frame
+// SEI NALU before the first VCL NALU of each sample, updating Data and Size. samples
+// are the video track's FullSamples in decode order; fps and unitStartMS give the
+// caption timing; segNr is this unit's segment number and nextSegNr the segment
+// number of the unit that follows (the same segment for a non-final fragment).
+//
+// The schedule is presentation-ordered but samples arrive in decode order. Since
+// receivers reassemble cc_data by presentation time (PTS) — dash.js, hls.js and
+// Shaka all sort caption pairs by PTS — the k-th caption frame must ride the k-th
+// sample in *presentation* order. With B-frames (decode order != presentation order)
+// a naive frames[i]->samples[i] mapping permutes the CEA-608 byte stream and garbles
+// the caption.
+func injectCC608(samples []mp4.FullSample, fps float64, unitStartMS int64, segNr, nextSegNr uint32, codec carriage.Codec) error {
 	if len(samples) == 0 {
 		return nil
 	}
-	// BuildUnitCues validates the frame rate and returns an error (never panics)
+	// cc608UnitFrames validates the frame rate and returns an error (never panics)
 	// if it is out of the CEA-608 range.
-	frames, err := generate.BuildUnitCues(fps, len(samples), unitStartMS, cc608TargetPeriodMS, cc608CueContent(segNr))
+	frames, err := cc608UnitFrames(fps, len(samples), unitStartMS, cc608CueContent(segNr), cc608CueContent(nextSegNr))
 	if err != nil {
 		return fmt.Errorf("cc608 build cues: %w", err)
 	}
@@ -157,6 +268,12 @@ func isVCLNalu(nalu []byte, codec carriage.Codec) bool {
 // so there is no senc/saio to adjust; and since only per-sample size *values*
 // change, the moof size is unchanged and trun.DataOffset / mdat.StartPos stay
 // valid (mirroring the tfdt-shift bookkeeping in genLiveSegment).
+//
+// Each fragment is one caption unit. Because a cue's build is transmitted ahead of
+// its flip (see cc608UnitFrames), a fragment also carries the build for the first
+// cue of whatever follows it: the next fragment of this segment, or — for the last
+// fragment — the first cue of the next segment, which is why the next unit's segment
+// number is passed down.
 func applyCC608(seg *mp4.MediaSegment, meta segMeta, cfg *ResponseConfig) error {
 	rep := meta.rep
 	codec, ok := cc608CodecFor(rep.Codecs)
@@ -167,7 +284,7 @@ func applyCC608(seg *mp4.MediaSegment, meta segMeta, cfg *ResponseConfig) error 
 		return fmt.Errorf("cc608: missing init/trex for representation %q", rep.ID)
 	}
 	trex := rep.initSeg.Moov.Mvex.Trex
-	for _, frag := range seg.Fragments {
+	for i, frag := range seg.Fragments {
 		samples, err := frag.GetFullSamples(trex)
 		if err != nil {
 			return fmt.Errorf("cc608 getFullSamples: %w", err)
@@ -181,7 +298,13 @@ func applyCC608(seg *mp4.MediaSegment, meta segMeta, cfg *ResponseConfig) error 
 		}
 		fragStart := frag.Moof.Traf.Tfdt.BaseMediaDecodeTime()
 		unitStartMS := int64(cfg.StartTimeS)*1000 + int64(fragStart)*1000/int64(meta.timescale)
-		if err := injectCC608(samples, fps, unitStartMS, meta.newNr, codec); err != nil {
+		// The unit after the last fragment is the next segment; earlier fragments are
+		// followed by another fragment of this segment, which keeps the same number.
+		nextSegNr := meta.newNr
+		if i == len(seg.Fragments)-1 {
+			nextSegNr = meta.newNr + 1
+		}
+		if err := injectCC608(samples, fps, unitStartMS, meta.newNr, nextSegNr, codec); err != nil {
 			return err
 		}
 		if err := writeBackCC608Samples(frag, samples); err != nil {

--- a/cmd/livesim2/app/cc608_inject.go
+++ b/cmd/livesim2/app/cc608_inject.go
@@ -85,17 +85,36 @@ func cc608PairCount(toks []cta608.Token) int {
 	})) / 2
 }
 
+// cc608FlipMode selects where a cue's pop-on flip lands relative to the cue it names.
+type cc608FlipMode int
+
+const (
+	// cc608FlipAtCueStart puts each EOC on its cue's first frame, transmitting the
+	// build over the preceding frames. Frame-accurate, but captions span unit
+	// boundaries. This is the default.
+	cc608FlipAtCueStart cc608FlipMode = iota
+	// cc608SelfContained keeps a cue's build and flip inside the cue's own frames, so
+	// no unit depends on its neighbour. The flip lands ~build-pairs frames into the
+	// cue, i.e. the caption lags the interval its text names.
+	cc608SelfContained
+)
+
 // cc608UnitFrames builds the per-frame CTA-608 schedule for one unit (one fragment)
 // of nFrames frames starting at unitStartMS.
 //
 // A pop-on caption occupies two transmissions: a build (RCL + ENM + rows) written
 // into non-displayed memory, and an EOC that flips it on screen. Both drain at one
-// 608 pair per frame, so where the build is placed decides when the caption
-// appears. go-608's generate.BuildUnitCues starts the build at its cue's first
-// frame, which puts the flip ~pairs frames *into* the cue — ~0.5-0.75s of a
-// one-second cue — so the caption became visible well after the time it displays.
+// 608 pair per frame, so where the build is placed decides when the caption appears.
 //
-// Here each cue's EOC rides its cue's first frame and its build drains over the
+// With mode cc608SelfContained, both ride the cue's own frames: the build drains from
+// the cue's first frame and the flip follows it, which puts the flip ~pairs frames
+// *into* the cue — 0.6-0.75s of a one-second cue — so the caption is visible well
+// after the time its text names. Nothing crosses a unit boundary, so every segment
+// decodes standalone and a client that starts, seeks or joins anywhere sees a correct
+// (if late) caption. nextContent is unused in this mode.
+//
+// With the default cc608FlipAtCueStart, each cue's EOC rides its cue's first frame
+// and its build drains over the
 // frames immediately before it, so the flip coincides with the cue boundary and the
 // caption is shown exactly over the interval its text names. The consequence is that
 // a cue's build lives in the preceding cue's frames: the first cue's build belongs to
@@ -110,12 +129,15 @@ func cc608PairCount(toks []cta608.Token) int {
 // case into the blank one — and not something the server can paper over, since an ENM
 // ahead of the EOC would erase the build about to be flipped.
 //
-// Each cue is encoded with a fresh cta608.Encoder so its build is always a complete
-// rebuild. That keeps every EOC paired with a build that fully describes its screen,
-// which is what makes independently generated, on-demand units line up: the build in
-// unit N's tail and the flip at unit N+1's first frame are produced by separate
-// calls and must agree without sharing encoder state.
-func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextContent generate.CueContentFunc) ([]schedule.Frame, error) {
+// In both modes each cue is encoded with a fresh cta608.Encoder so its build is always
+// a complete rebuild rather than a diff against the previous cue. That keeps every EOC
+// paired with a build that fully describes its screen, which is what makes
+// independently generated, on-demand units line up: the build in unit N's tail and the
+// flip at unit N+1's first frame are produced by separate calls and must agree without
+// sharing encoder state. It is also what lets a receiver joining mid-unit get a whole
+// caption rather than one row of one.
+func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextContent generate.CueContentFunc,
+	mode cc608FlipMode) ([]schedule.Frame, error) {
 	if nFrames <= 0 {
 		return nil, fmt.Errorf("cc608: nFrames must be > 0, got %d", nFrames)
 	}
@@ -130,6 +152,36 @@ func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextC
 	// boundary(k) is the first unit-relative frame of cue k; boundary(n) == nFrames.
 	boundary := func(k int) int { return int(math.Round(float64(k) * float64(nFrames) / float64(n))) }
 
+	// cueTokens encodes cue k from a clean encoder, split into the build and the EOC
+	// that flips it. Pushes drain in push order (the scheduler is a FIFO gated by
+	// eligibility time), so a build pushed before its EOC keeps the byte stream ordered.
+	cueTokens := func(cue generate.UnitCue) (build, eoc []cta608.Token) {
+		var enc cta608.Encoder
+		return cc608SplitEOC(enc.Apply(cta608.CaptionBlock{Lines: cue.Lines, Mode: cta608.PopOn}))
+	}
+
+	sched := schedule.NewScheduler(fps, schedule.WithDoubling(cta608.DoublingOff))
+	if mode == cc608SelfContained {
+		for k := 0; k < n; k++ {
+			start, end := boundary(k), boundary(k+1)
+			build, eoc := cueTokens(content(k, wallAt(start)))
+			// Build and EOC are both eligible at the cue's first frame and drain one pair
+			// per frame, so the flip lands at start+pairs. Require it to leave at least
+			// one frame of display before the next cue takes the screen.
+			if pairs := cc608PairCount(build) + cc608PairCount(eoc); start+pairs >= end {
+				return nil, fmt.Errorf("cc608: cue %d needs %d frames to build and flip but its slice is only "+
+					"%d frames at %g fps; shorten the lines or lower the update rate", k, pairs, end-start, fps)
+			}
+			if len(build) > 0 {
+				sched.Push(schedule.TimedTokens{TimeMS: wallAt(start), Field: 1, Tokens: build})
+			}
+			if len(eoc) > 0 {
+				sched.Push(schedule.TimedTokens{TimeMS: wallAt(start), Field: 1, Tokens: eoc})
+			}
+		}
+		return cc608CollectFrames(sched, nFrames, wallAt), nil
+	}
+
 	// Cue k flips at boundary(k). The extra entry at nFrames is the next unit's first
 	// cue: its build drains this unit's tail, its EOC belongs to the next unit.
 	type flip struct {
@@ -142,11 +194,9 @@ func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextC
 	}
 	flips = append(flips, flip{nFrames, nextContent(0, wallAt(nFrames))})
 
-	sched := schedule.NewScheduler(fps, schedule.WithDoubling(cta608.DoublingOff))
 	prevFlip := -1 // last frame already claimed by a flip
 	for i, f := range flips {
-		var enc cta608.Encoder
-		build, eoc := cc608SplitEOC(enc.Apply(cta608.CaptionBlock{Lines: f.cue.Lines, Mode: cta608.PopOn}))
+		build, eoc := cueTokens(f.cue)
 		buildStart := f.frame - cc608PairCount(build)
 		// The first cue flips at frame 0, so its build was transmitted by the previous
 		// unit and there is nothing to place here. Every other build must fit between
@@ -158,9 +208,6 @@ func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextC
 				return nil, fmt.Errorf("cc608: cue flipping at frame %d needs %d frames of build but only %d are free "+
 					"at %g fps; shorten the lines or lower the update rate", f.frame, f.frame-buildStart, free, fps)
 			}
-			// Pushes drain in push order (the scheduler is a FIFO gated by eligibility
-			// time), so pushing the build before its EOC keeps the byte stream ordered
-			// and lands the flip on f.frame exactly.
 			sched.Push(schedule.TimedTokens{TimeMS: wallAt(buildStart), Field: 1, Tokens: build})
 		}
 		if f.frame < nFrames && len(eoc) > 0 {
@@ -168,12 +215,16 @@ func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextC
 		}
 		prevFlip = f.frame
 	}
+	return cc608CollectFrames(sched, nFrames, wallAt), nil
+}
 
+// cc608CollectFrames drains the scheduler into one entry per unit frame.
+func cc608CollectFrames(sched *schedule.Scheduler, nFrames int, wallAt func(int) int64) []schedule.Frame {
 	frames := make([]schedule.Frame, nFrames)
 	for i := range frames {
 		frames[i] = sched.Frame(wallAt(i))
 	}
-	return frames, nil
+	return frames
 }
 
 // injectCC608 splices in-band CTA-608 caption SEI into a unit's video samples in
@@ -182,7 +233,8 @@ func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextC
 // SEI NALU before the first VCL NALU of each sample, updating Data and Size. samples
 // are the video track's FullSamples in decode order; fps and unitStartMS give the
 // caption timing; segNr is this unit's segment number and nextSegNr the segment
-// number of the unit that follows (the same segment for a non-final fragment).
+// number of the unit that follows (the same segment for a non-final fragment); mode
+// selects where each cue flips (nextSegNr is unused for cc608SelfContained).
 //
 // The schedule is presentation-ordered but samples arrive in decode order. Since
 // receivers reassemble cc_data by presentation time (PTS) — dash.js, hls.js and
@@ -190,13 +242,14 @@ func cc608UnitFrames(fps float64, nFrames int, unitStartMS int64, content, nextC
 // sample in *presentation* order. With B-frames (decode order != presentation order)
 // a naive frames[i]->samples[i] mapping permutes the CEA-608 byte stream and garbles
 // the caption.
-func injectCC608(samples []mp4.FullSample, fps float64, unitStartMS int64, segNr, nextSegNr uint32, codec carriage.Codec) error {
+func injectCC608(samples []mp4.FullSample, fps float64, unitStartMS int64, segNr, nextSegNr uint32,
+	codec carriage.Codec, mode cc608FlipMode) error {
 	if len(samples) == 0 {
 		return nil
 	}
 	// cc608UnitFrames validates the frame rate and returns an error (never panics)
 	// if it is out of the CEA-608 range.
-	frames, err := cc608UnitFrames(fps, len(samples), unitStartMS, cc608CueContent(segNr), cc608CueContent(nextSegNr))
+	frames, err := cc608UnitFrames(fps, len(samples), unitStartMS, cc608CueContent(segNr), cc608CueContent(nextSegNr), mode)
 	if err != nil {
 		return fmt.Errorf("cc608 build cues: %w", err)
 	}
@@ -275,11 +328,12 @@ func isVCLNalu(nalu []byte, codec carriage.Codec) bool {
 // change, the moof size is unchanged and trun.DataOffset / mdat.StartPos stay
 // valid (mirroring the tfdt-shift bookkeeping in genLiveSegment).
 //
-// Each fragment is one caption unit. Because a cue's build is transmitted ahead of
-// its flip (see cc608UnitFrames), a fragment also carries the build for the first
-// cue of whatever follows it: the next fragment of this segment, or — for the last
+// Each fragment is one caption unit. In the default mode a cue's build is transmitted
+// ahead of its flip (see cc608UnitFrames), so a fragment also carries the build for the
+// first cue of whatever follows it: the next fragment of this segment, or — for the last
 // fragment — the first cue of the next segment, which is why the next unit's segment
-// number is passed down.
+// number is passed down. With timecc608's "-sc" (CC608Config.SelfContained) each unit
+// keeps its captions to itself and the next number goes unused.
 func applyCC608(seg *mp4.MediaSegment, meta segMeta, cfg *ResponseConfig) error {
 	rep := meta.rep
 	codec, ok := cc608CodecFor(rep.Codecs)
@@ -288,6 +342,10 @@ func applyCC608(seg *mp4.MediaSegment, meta segMeta, cfg *ResponseConfig) error 
 	}
 	if rep.initSeg == nil || rep.initSeg.Moov == nil || rep.initSeg.Moov.Mvex == nil {
 		return fmt.Errorf("cc608: missing init/trex for representation %q", rep.ID)
+	}
+	mode := cc608FlipAtCueStart
+	if cfg.CC608 != nil && cfg.CC608.SelfContained {
+		mode = cc608SelfContained
 	}
 	trex := rep.initSeg.Moov.Mvex.Trex
 	for i, frag := range seg.Fragments {
@@ -310,7 +368,7 @@ func applyCC608(seg *mp4.MediaSegment, meta segMeta, cfg *ResponseConfig) error 
 		if i == len(seg.Fragments)-1 {
 			nextSegNr = meta.newNr + 1
 		}
-		if err := injectCC608(samples, fps, unitStartMS, meta.newNr, nextSegNr, codec); err != nil {
+		if err := injectCC608(samples, fps, unitStartMS, meta.newNr, nextSegNr, codec, mode); err != nil {
 			return err
 		}
 		if err := writeBackCC608Samples(frag, samples); err != nil {

--- a/cmd/livesim2/app/cc608_inject.go
+++ b/cmd/livesim2/app/cc608_inject.go
@@ -105,8 +105,10 @@ func cc608PairCount(toks []cta608.Token) int {
 // to it. What it shows for that cue period depends on its decoder state: a fresh
 // decoder has empty non-displayed memory and shows nothing, while one that keeps 608
 // state across the discontinuity flips whatever was last preloaded and can show a
-// stale caption. Either way it is correct from the next cue on, and the server cannot
-// prevent it — an ENM ahead of the EOC would erase the build about to be flipped.
+// stale caption. Either way it is correct from the next cue on. Recovering faster is a
+// receiver-side matter — a player resetting its 608 state on a seek turns the stale
+// case into the blank one — and not something the server can paper over, since an ENM
+// ahead of the EOC would erase the build about to be flipped.
 //
 // Each cue is encoded with a fresh cta608.Encoder so its build is always a complete
 // rebuild. That keeps every EOC paired with a build that fully describes its screen,

--- a/cmd/livesim2/app/cc608_inject.go
+++ b/cmd/livesim2/app/cc608_inject.go
@@ -100,9 +100,13 @@ func cc608PairCount(toks []cta608.Token) int {
 // caption is shown exactly over the interval its text names. The consequence is that
 // a cue's build lives in the preceding cue's frames: the first cue's build belongs to
 // the *previous* unit, and this unit's tail carries the build for the next unit's
-// first cue (nextContent). Captions therefore span unit boundaries — a receiver
-// starting mid-stream gets the first EOC without its build and shows no caption for
-// one cue period, then is correct.
+// first cue (nextContent). Captions therefore span unit boundaries — a receiver that
+// starts, seeks, or joins mid-stream gets the first EOC without the build that belongs
+// to it. What it shows for that cue period depends on its decoder state: a fresh
+// decoder has empty non-displayed memory and shows nothing, while one that keeps 608
+// state across the discontinuity flips whatever was last preloaded and can show a
+// stale caption. Either way it is correct from the next cue on, and the server cannot
+// prevent it — an ENM ahead of the EOC would erase the build about to be flipped.
 //
 // Each cue is encoded with a fresh cta608.Encoder so its build is always a complete
 // rebuild. That keeps every EOC paired with a build that fully describes its screen,

--- a/cmd/livesim2/app/cc608_inject_test.go
+++ b/cmd/livesim2/app/cc608_inject_test.go
@@ -7,6 +7,7 @@ package app
 import (
 	"encoding/binary"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"sort"
@@ -132,51 +133,134 @@ func TestInjectCC608HEVC(t *testing.T) {
 	testInjectCC608(t, carriage.CodecHEVC, []byte{0x26, 0x01, 0x80, 0x00})
 }
 
+// cc608TestSamples returns nFrames identical samples carrying just vclNalu.
+func cc608TestSamples(nFrames int, vclNalu []byte) []mp4.FullSample {
+	samples := make([]mp4.FullSample, nFrames)
+	size := len(avccSample(vclNalu))
+	for i := range samples {
+		samples[i] = mp4.FullSample{
+			Sample: mp4.Sample{Size: uint32(size)},
+			Data:   avccSample(vclNalu),
+		}
+	}
+	return samples
+}
+
+// testInjectCC608 injects two consecutive units and decodes them as one stream.
+//
+// Two units are needed because a cue's build is transmitted ahead of its flip: the
+// build for unit B's first cue rides unit A's tail, so only a two-unit stream can
+// show that the flip lands on the unit boundary with the right text. Within a unit,
+// the flip for cue k lands on cue k's first frame.
 func testInjectCC608(t *testing.T, codec carriage.Codec, vclNalu []byte) {
 	t.Helper()
 	const fps = 30.0
 	const nFrames = 60 // 2 s at 30 fps -> 2 cues
-	unitStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
+	unitAStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
+	unitBStart := unitAStart + 2000
 
-	samples := make([]mp4.FullSample, nFrames)
+	unitA := cc608TestSamples(nFrames, vclNalu)
+	unitB := cc608TestSamples(nFrames, vclNalu)
 	origSize := len(avccSample(vclNalu))
-	for i := range samples {
-		samples[i] = mp4.FullSample{
-			Sample: mp4.Sample{Size: uint32(origSize)},
-			Data:   avccSample(vclNalu),
-		}
-	}
 
-	require.NoError(t, injectCC608(samples, fps, unitStart, 42, codec))
+	require.NoError(t, injectCC608(unitA, fps, unitAStart, 42, 43, codec))
+	require.NoError(t, injectCC608(unitB, fps, unitBStart, 43, 44, codec))
 
 	// Every sample gained an SEI NALU placed before the VCL, and Size was updated.
-	for i := range samples {
-		nalus, err := avc.GetNalusFromSample(samples[i].Data)
-		require.NoError(t, err, "sample %d", i)
-		require.Len(t, nalus, 2, "sample %d: SEI + VCL", i)
-		if codec == carriage.CodecHEVC {
-			require.Equal(t, hevc.NALU_SEI_PREFIX, hevc.GetNaluType(nalus[0][0]))
-		} else {
-			require.Equal(t, avc.NALU_SEI, avc.GetNaluType(nalus[0][0]))
+	for _, samples := range [][]mp4.FullSample{unitA, unitB} {
+		for i := range samples {
+			nalus, err := avc.GetNalusFromSample(samples[i].Data)
+			require.NoError(t, err, "sample %d", i)
+			require.Len(t, nalus, 2, "sample %d: SEI + VCL", i)
+			if codec == carriage.CodecHEVC {
+				require.Equal(t, hevc.NALU_SEI_PREFIX, hevc.GetNaluType(nalus[0][0]))
+			} else {
+				require.Equal(t, avc.NALU_SEI, avc.GetNaluType(nalus[0][0]))
+			}
+			require.True(t, isVCLNalu(nalus[1], codec), "sample %d VCL after SEI", i)
+			require.Equal(t, uint32(len(samples[i].Data)), samples[i].Size, "sample %d Size", i)
+			require.Greater(t, len(samples[i].Data), origSize, "sample %d grew", i)
 		}
-		require.True(t, isVCLNalu(nalus[1], codec), "sample %d VCL after SEI", i)
-		require.Equal(t, uint32(len(samples[i].Data)), samples[i].Size, "sample %d Size", i)
-		require.Greater(t, len(samples[i].Data), origSize, "sample %d grew", i)
 	}
 
-	// The injected captions decode to the two per-second cues with the seg number.
-	flips := decodeSamples(t, samples, codec)
-	require.Len(t, flips, 2, "one flip per cue")
-	require.Equal(t, "14:23:44.000", flips[0].line1)
-	require.Equal(t, "SEG 42", flips[0].line2)
-	require.Equal(t, "14:23:45.000", flips[1].line1)
-	require.Equal(t, "SEG 42", flips[1].line2)
+	// Decoded as one continuous stream, every flip lands on a cue boundary (frames
+	// 30, 60, 90) and shows the time of the interval it is displayed over. Unit A's
+	// own first cue (frame 0) has no build here — it would have come from the unit
+	// before A — which is the documented mid-stream-join behaviour.
+	flips := decodeSamples(t, append(append([]mp4.FullSample{}, unitA...), unitB...), codec)
+	require.Equal(t, []cc608Flip{
+		{30, "14:23:45.000", "SEG 42"},
+		{60, "14:23:46.000", "SEG 43"}, // built in unit A's tail, flipped by unit B
+		{90, "14:23:47.000", "SEG 43"},
+	}, flips)
 }
 
-// TestGenLiveSegmentCC608 drives a real testpic_2s/V300 (AVC) segment through
-// genLiveSegment with timecc608 set, round-trips it through the real encode path,
-// and verifies every video sample carries CEA-608 SEI that decodes to the clock +
-// segment number.
+// TestCC608UnitFramesBuildDoesNotFit checks that a unit too short to carry the build
+// for the next cue is reported rather than silently producing an EOC with nothing
+// loaded (a caption that would never appear).
+func TestCC608UnitFramesBuildDoesNotFit(t *testing.T) {
+	unitStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
+	_, err := cc608UnitFrames(30.0, 10, unitStart, cc608CueContent(42), cc608CueContent(43))
+	require.ErrorContains(t, err, "frames of build but only")
+}
+
+// TestInjectCC608FirstCueUnbuilt documents what a receiver sees when it starts on a
+// unit whose first cue was built in the previous (unavailable) unit: the leading EOC
+// flips an unloaded screen, so there is no caption until the next cue boundary,
+// rather than a stale or garbled one.
+func TestInjectCC608FirstCueUnbuilt(t *testing.T) {
+	const fps = 30.0
+	const nFrames = 60
+	unitStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
+	samples := cc608TestSamples(nFrames, []byte{0x65, 0x88, 0x80, 0x00})
+
+	require.NoError(t, injectCC608(samples, fps, unitStart, 42, 43, carriage.CodecAVC))
+
+	flips := decodeSamples(t, samples, carriage.CodecAVC)
+	require.Equal(t, []cc608Flip{
+		{30, "14:23:45.000", "SEG 42"},
+	}, flips, "only the cue whose build is inside this unit appears")
+}
+
+// cc608SegSamples generates one segment through genLiveSegment and returns its video
+// samples. With roundTrip set, the segment is encoded and re-decoded first, which
+// validates the injection's size bookkeeping through the real encode path.
+func cc608SegSamples(t *testing.T, vodFS fs.FS, a *asset, cfg *ResponseConfig, media string, nowMS int, roundTrip bool) []mp4.FullSample {
+	t.Helper()
+	so, err := genLiveSegment(slog.Default(), vodFS, a, cfg, media, nowMS, false)
+	require.NoError(t, err)
+	require.Equal(t, "video/mp4", so.meta.rep.SegmentType())
+
+	seg := so.seg
+	if roundTrip {
+		sw := bits.NewFixedSliceWriter(int(so.seg.Size()))
+		require.NoError(t, so.seg.EncodeSW(sw))
+		decoded, err := mp4.DecodeFileSR(bits.NewFixedSliceReader(sw.Bytes()))
+		require.NoError(t, err)
+		require.Len(t, decoded.Segments, 1)
+		seg = decoded.Segments[0]
+	}
+
+	trex := so.meta.rep.initSeg.Moov.Mvex.Trex
+	var samples []mp4.FullSample
+	for _, frag := range seg.Fragments {
+		fss, err := frag.GetFullSamples(trex)
+		require.NoError(t, err)
+		samples = append(samples, fss...)
+	}
+	require.NotEmpty(t, samples)
+	return samples
+}
+
+// TestGenLiveSegmentCC608 drives two consecutive real testpic_2s/V300 (AVC) segments
+// through genLiveSegment with timecc608 set, round-trips them through the real encode
+// path, and verifies every video sample carries CEA-608 SEI that decodes to the clock
+// + segment number.
+//
+// Two segments are required: a cue's build is transmitted during the preceding cue,
+// so the first caption of segment 41 is built in segment 40's tail. Decoding the pair
+// as one stream is what proves the flip lands on the segment boundary carrying the
+// next segment's number.
 func TestGenLiveSegmentCC608(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	am := newAssetMgr(vodFS, "", false, false)
@@ -188,27 +272,12 @@ func TestGenLiveSegmentCC608(t *testing.T) {
 	cfg := NewResponseConfig()
 	cfg.CC608 = &CC608Config{Channel: "CC1", Lang: "eng"}
 	const nowMS = 100_000
-	const nr = 40
+	const nr = 40 // 2s segments -> segment 40 starts at 80s = 00:01:20
 
-	so, err := genLiveSegment(logger, vodFS, asset, cfg, fmt.Sprintf("V300/%d.m4s", nr), nowMS, false)
-	require.NoError(t, err)
-	require.Equal(t, "video/mp4", so.meta.rep.SegmentType())
-
-	// Round-trip through the real encode path to validate the size bookkeeping.
-	sw := bits.NewFixedSliceWriter(int(so.seg.Size()))
-	require.NoError(t, so.seg.EncodeSW(sw))
-	decoded, err := mp4.DecodeFileSR(bits.NewFixedSliceReader(sw.Bytes()))
-	require.NoError(t, err)
-	require.Len(t, decoded.Segments, 1)
-
-	trex := so.meta.rep.initSeg.Moov.Mvex.Trex
 	var samples []mp4.FullSample
-	for _, frag := range decoded.Segments[0].Fragments {
-		fss, err := frag.GetFullSamples(trex)
-		require.NoError(t, err)
-		samples = append(samples, fss...)
+	for _, n := range []int{nr, nr + 1} {
+		samples = append(samples, cc608SegSamples(t, vodFS, asset, cfg, fmt.Sprintf("V300/%d.m4s", n), nowMS, true)...)
 	}
-	require.NotEmpty(t, samples)
 	for i := range samples {
 		require.True(t, avc.ContainsNaluType(samples[i].Data, avc.NALU_SEI), "sample %d missing SEI", i)
 	}
@@ -217,23 +286,25 @@ func TestGenLiveSegmentCC608(t *testing.T) {
 	for i, fl := range flips {
 		t.Logf("cue %d @rank %d: line1=%q line2=%q", i, fl.frame, fl.line1, fl.line2)
 	}
-	// A 2s segment at 30fps has N=2 cues; both must decode (in presentation order),
-	// each two lines, and the times must tick by one second.
-	require.Len(t, flips, 2, "two ticking cues per 2s segment")
-	require.Regexp(t, `^\d\d:\d\d:\d\d\.\d\d\d$`, flips[0].line1)
-	require.Regexp(t, `^SEG \d+$`, flips[0].line2)
-	require.Regexp(t, `^\d\d:\d\d:\d\d\.\d\d\d$`, flips[1].line1)
-	require.Equal(t, flips[0].line2, flips[1].line2, "segment number is constant across the segment's cues")
-	require.NotEqual(t, flips[0].line1, flips[1].line1, "the two cues must show different (ticking) times")
+	// Each 2s segment at 30fps holds two ~1s cues. Across the pair the visible flips
+	// are: segment 40's second cue (frame 30), then segment 41's two cues at frames 60
+	// and 90 — the frame-60 flip being the one built in segment 40's tail. Segment 40's
+	// own first cue was built in segment 39, which is not part of this stream.
+	require.Equal(t, []cc608Flip{
+		{30, "00:01:21.000", "SEG 40"},
+		{60, "00:01:22.000", "SEG 41"},
+		{90, "00:01:23.000", "SEG 41"},
+	}, flips)
 }
 
 // TestGenLiveSegmentCC608HEVC is the HEVC counterpart of TestGenLiveSegmentCC608:
-// it drives a real hev1 segment (bbb_hevc_ac3_8s, 24 fps, 2s segments) through
-// genLiveSegment with timecc608, round-trips it through the encode path, and
-// verifies every video sample carries a CEA-608 SEI prefix NAL that decodes (in
-// presentation order) to the ticking clock + segment number. This proves the
-// injection path — SEI splicing, VCL detection, presentation-order distribution and
-// the trun/mdat write-back — is codec-generic for HEVC end to end.
+// it drives two consecutive real hev1 segments (bbb_hevc_ac3_8s, 24 fps, 2s
+// segments) through genLiveSegment with timecc608, round-trips them through the
+// encode path, and verifies every video sample carries a CEA-608 SEI prefix NAL that
+// decodes (in presentation order) to the ticking clock + segment number. This proves
+// the injection path — SEI splicing, VCL detection, presentation-order distribution
+// and the trun/mdat write-back — is codec-generic for HEVC end to end, including the
+// cue whose build crosses the segment boundary.
 func TestGenLiveSegmentCC608HEVC(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	am := newAssetMgr(vodFS, "", false, false)
@@ -247,38 +318,20 @@ func TestGenLiveSegmentCC608HEVC(t *testing.T) {
 	const nowMS = 100_000
 	const nr = 40 // 2s segments -> segment 40 starts at 80s = 00:01:20
 
-	so, err := genLiveSegment(logger, vodFS, asset, cfg, fmt.Sprintf("video_%d.m4s", nr), nowMS, false)
-	require.NoError(t, err)
-	require.Equal(t, "video/mp4", so.meta.rep.SegmentType())
-	codec, ok := cc608CodecFor(so.meta.rep.Codecs)
-	require.True(t, ok)
-	require.Equal(t, carriage.CodecHEVC, codec)
-
-	// Round-trip through the real encode path to validate the size bookkeeping.
-	sw := bits.NewFixedSliceWriter(int(so.seg.Size()))
-	require.NoError(t, so.seg.EncodeSW(sw))
-	decoded, err := mp4.DecodeFileSR(bits.NewFixedSliceReader(sw.Bytes()))
-	require.NoError(t, err)
-	require.Len(t, decoded.Segments, 1)
-
-	trex := so.meta.rep.initSeg.Moov.Mvex.Trex
 	var samples []mp4.FullSample
-	for _, frag := range decoded.Segments[0].Fragments {
-		fss, err := frag.GetFullSamples(trex)
-		require.NoError(t, err)
-		samples = append(samples, fss...)
+	for _, n := range []int{nr, nr + 1} {
+		samples = append(samples, cc608SegSamples(t, vodFS, asset, cfg, fmt.Sprintf("video_%d.m4s", n), nowMS, true)...)
 	}
-	require.NotEmpty(t, samples)
 	for i := range samples {
 		require.True(t, hevc.ContainsNaluType(samples[i].Data, hevc.NALU_SEI_PREFIX), "sample %d missing SEI", i)
 	}
 
 	flips := decodeSamples(t, samples, carriage.CodecHEVC)
-	require.Len(t, flips, 2, "two ticking cues per 2s segment")
-	require.Equal(t, "00:01:20.000", flips[0].line1)
-	require.Equal(t, "SEG 40", flips[0].line2)
-	require.Equal(t, "00:01:21.000", flips[1].line1)
-	require.Equal(t, "SEG 40", flips[1].line2)
+	require.Equal(t, []cc608Flip{
+		{24, "00:01:21.000", "SEG 40"},
+		{48, "00:01:22.000", "SEG 41"}, // built in segment 40's tail
+		{72, "00:01:23.000", "SEG 41"},
+	}, flips)
 }
 
 // TestPrepareChunksCC608 exercises the low-latency chunked path: a chunked
@@ -319,20 +372,23 @@ func TestPrepareChunksCC608(t *testing.T) {
 		samples = append(samples, fss...)
 	}
 
+	// Reassembled across the chunks, the segment's second cue flips on its boundary.
+	// The first cue's build lives in segment 39, which this test does not fetch (see
+	// TestGenLiveSegmentCC608 for the cross-segment case).
 	flips := decodeSamples(t, samples, carriage.CodecAVC)
-	require.Len(t, flips, 2, "two ticking cues per 2s segment, reassembled across the chunks")
-	require.Equal(t, "00:01:20.000", flips[0].line1)
-	require.Equal(t, "SEG 40", flips[0].line2)
-	require.Equal(t, "00:01:21.000", flips[1].line1)
-	require.Equal(t, "SEG 40", flips[1].line2)
+	require.Equal(t, []cc608Flip{
+		{30, "00:01:21.000", "SEG 40"},
+	}, flips)
 }
 
-// TestGenLiveSegmentCC608_2997fps drives a real 29.97 fps (30000/1001) AVC asset
-// through genLiveSegment with timecc608. Unlike the 30 fps testpic assets, this
-// content has non-integer fps and 2.002s segments, so it checks that the go-608 fps
-// guard accepts 29.97, that the caption pairs are distributed one-per-frame over the
-// 60 frames, and that the two per-second cues stay frame-accurate to the wall clock
-// (segment 40 starts at 40*2.002s = 80.08s = 00:01:20.080).
+// TestGenLiveSegmentCC608_2997fps drives two consecutive real 29.97 fps (30000/1001)
+// AVC segments through genLiveSegment with timecc608. Unlike the 30 fps testpic
+// assets, this content has non-integer fps and 2.002s segments, so it checks that the
+// go-608 fps guard accepts 29.97, that the caption pairs are distributed one-per-frame
+// over the 60 frames, and that the cues stay frame-accurate to the wall clock across a
+// segment boundary — where a fractional frame duration is most likely to drift, since
+// the cue built at the end of segment 40 must name exactly the start of segment 41
+// (40*2.002s = 80.080s, so segment 41 starts at 82.082s = 00:01:22.082).
 func TestGenLiveSegmentCC608_2997fps(t *testing.T) {
 	vodFS := os.DirFS("testdata/assets")
 	am := newAssetMgr(vodFS, "", false, false)
@@ -346,31 +402,20 @@ func TestGenLiveSegmentCC608_2997fps(t *testing.T) {
 	const nowMS = 100_000
 	const nr = 40
 
-	so, err := genLiveSegment(logger, vodFS, asset, cfg, fmt.Sprintf("video/avc1/seg-%d.m4s", nr), nowMS, false)
-	require.NoError(t, err)
-	require.Equal(t, "video/mp4", so.meta.rep.SegmentType())
-	require.EqualValues(t, 30000, so.meta.rep.MediaTimescale)
-	require.EqualValues(t, 1001, so.meta.rep.sampleDur()) // 30000/1001 = 29.97 fps
-
-	trex := so.meta.rep.initSeg.Moov.Mvex.Trex
 	var samples []mp4.FullSample
-	for _, frag := range so.seg.Fragments {
-		fss, err := frag.GetFullSamples(trex)
-		require.NoError(t, err)
-		samples = append(samples, fss...)
+	for _, n := range []int{nr, nr + 1} {
+		samples = append(samples, cc608SegSamples(t, vodFS, asset, cfg, fmt.Sprintf("video/avc1/seg-%d.m4s", n), nowMS, false)...)
 	}
-	require.NotEmpty(t, samples)
 	for i := range samples {
 		require.True(t, avc.ContainsNaluType(samples[i].Data, avc.NALU_SEI), "sample %d missing SEI", i)
 	}
 
 	flips := decodeSamples(t, samples, carriage.CodecAVC)
-	require.Len(t, flips, 2, "two ticking cues per 2.002s segment")
-	// 40*2.002s = 80.080s; the second cue is ~1.001s later.
-	require.Equal(t, "00:01:20.080", flips[0].line1)
-	require.Equal(t, "SEG 40", flips[0].line2)
-	require.Equal(t, "00:01:21.081", flips[1].line1)
-	require.Equal(t, "SEG 40", flips[1].line2)
+	require.Equal(t, []cc608Flip{
+		{30, "00:01:21.081", "SEG 40"},
+		{60, "00:01:22.082", "SEG 41"}, // built in segment 40's tail, on the boundary
+		{90, "00:01:23.083", "SEG 41"},
+	}, flips)
 }
 
 // TestGenLiveSegmentCC608AudioUnchanged confirms timecc608 is a no-op for audio

--- a/cmd/livesim2/app/cc608_inject_test.go
+++ b/cmd/livesim2/app/cc608_inject_test.go
@@ -163,8 +163,8 @@ func testInjectCC608(t *testing.T, codec carriage.Codec, vclNalu []byte) {
 	unitB := cc608TestSamples(nFrames, vclNalu)
 	origSize := len(avccSample(vclNalu))
 
-	require.NoError(t, injectCC608(unitA, fps, unitAStart, 42, 43, codec))
-	require.NoError(t, injectCC608(unitB, fps, unitBStart, 43, 44, codec))
+	require.NoError(t, injectCC608(unitA, fps, unitAStart, 42, 43, codec, cc608FlipAtCueStart))
+	require.NoError(t, injectCC608(unitB, fps, unitBStart, 43, 44, codec, cc608FlipAtCueStart))
 
 	// Every sample gained an SEI NALU placed before the VCL, and Size was updated.
 	for _, samples := range [][]mp4.FullSample{unitA, unitB} {
@@ -200,8 +200,46 @@ func testInjectCC608(t *testing.T, codec carriage.Codec, vclNalu []byte) {
 // loaded (a caption that would never appear).
 func TestCC608UnitFramesBuildDoesNotFit(t *testing.T) {
 	unitStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
-	_, err := cc608UnitFrames(30.0, 10, unitStart, cc608CueContent(42), cc608CueContent(43))
+	_, err := cc608UnitFrames(30.0, 10, unitStart, cc608CueContent(42), cc608CueContent(43), cc608FlipAtCueStart)
 	require.ErrorContains(t, err, "frames of build but only")
+}
+
+// TestInjectCC608SelfContained covers timecc608's "-sc" mode, where a cue's build and
+// its flip both ride the cue's own frames. A single unit then carries every caption it
+// shows: both cues appear from this unit alone, with no dependency on a neighbour — the
+// contrast with TestInjectCC608FirstCueUnbuilt, where the same unit shows only its
+// second cue. The price is latency: each flip lands build-pairs frames *into* its cue,
+// so the caption named 14:23:44 first appears a little over half a second late.
+func TestInjectCC608SelfContained(t *testing.T) {
+	const fps = 30.0
+	const nFrames = 60 // 2 s at 30 fps -> 2 cues
+	unitStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
+	samples := cc608TestSamples(nFrames, []byte{0x65, 0x88, 0x80, 0x00})
+
+	require.NoError(t, injectCC608(samples, fps, unitStart, 42, 43, carriage.CodecAVC, cc608SelfContained))
+
+	flips := decodeSamples(t, samples, carriage.CodecAVC)
+	require.Len(t, flips, 2, "both cues are visible from this unit alone")
+	require.Equal(t, "14:23:44.000", flips[0].line1)
+	require.Equal(t, "SEG 42", flips[0].line2)
+	require.Equal(t, "14:23:45.000", flips[1].line1)
+	require.Equal(t, "SEG 42", flips[1].line2)
+	// Each flip lags its cue's boundary (frames 0 and 30) by the build it had to drain,
+	// and still leaves display time before the next cue.
+	require.Greater(t, flips[0].frame, 0, "cue 0 flips after its build, not on frame 0")
+	require.Less(t, flips[0].frame, 30, "cue 0 is displayed before cue 1 takes over")
+	require.Greater(t, flips[1].frame, 30, "cue 1 flips after its build")
+	require.Less(t, flips[1].frame, nFrames)
+	t.Logf("self-contained flips at frames %d and %d (cue boundaries 0 and 30)", flips[0].frame, flips[1].frame)
+}
+
+// TestCC608UnitFramesSelfContainedDoesNotFit checks the self-contained counterpart of
+// TestCC608UnitFramesBuildDoesNotFit: cues too short to hold their own build and flip
+// are reported instead of emitting a caption that is never displayed.
+func TestCC608UnitFramesSelfContainedDoesNotFit(t *testing.T) {
+	unitStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
+	_, err := cc608UnitFrames(30.0, 10, unitStart, cc608CueContent(42), cc608CueContent(43), cc608SelfContained)
+	require.ErrorContains(t, err, "frames to build and flip")
 }
 
 // TestInjectCC608FirstCueUnbuilt documents what a receiver sees when it starts on a
@@ -214,7 +252,7 @@ func TestInjectCC608FirstCueUnbuilt(t *testing.T) {
 	unitStart := time.Date(2026, 7, 20, 14, 23, 44, 0, time.UTC).UnixMilli()
 	samples := cc608TestSamples(nFrames, []byte{0x65, 0x88, 0x80, 0x00})
 
-	require.NoError(t, injectCC608(samples, fps, unitStart, 42, 43, carriage.CodecAVC))
+	require.NoError(t, injectCC608(samples, fps, unitStart, 42, 43, carriage.CodecAVC, cc608FlipAtCueStart))
 
 	flips := decodeSamples(t, samples, carriage.CodecAVC)
 	require.Equal(t, []cc608Flip{
@@ -295,6 +333,38 @@ func TestGenLiveSegmentCC608(t *testing.T) {
 		{60, "00:01:22.000", "SEG 41"},
 		{90, "00:01:23.000", "SEG 41"},
 	}, flips)
+}
+
+// TestGenLiveSegmentCC608SelfContainedSegment drives the "-sc" mode through the real
+// request path (CC608Config.SelfContained -> applyCC608), which is what a client asking
+// for timecc608_CC1-eng-sc gets. One segment on its own must show both of its cues,
+// where the default mode shows only the second (TestGenLiveSegmentCC608 needs two
+// segments to see the first). Each flip lands inside the cue it names instead of on its
+// boundary, which is the latency this mode trades for self-containment.
+func TestGenLiveSegmentCC608SelfContainedSegment(t *testing.T) {
+	vodFS := os.DirFS("testdata/assets")
+	am := newAssetMgr(vodFS, "", false, false)
+	logger := slog.Default()
+	require.NoError(t, am.discoverAssets(logger))
+	asset, ok := am.findAsset("testpic_2s")
+	require.True(t, ok)
+
+	cfg := NewResponseConfig()
+	cfg.CC608 = &CC608Config{Channel: "CC1", Lang: "eng", SelfContained: true}
+	const nowMS = 100_000
+	const nr = 40 // 2s segments -> segment 40 starts at 80s = 00:01:20
+
+	samples := cc608SegSamples(t, vodFS, asset, cfg, fmt.Sprintf("V300/%d.m4s", nr), nowMS, true)
+	flips := decodeSamples(t, samples, carriage.CodecAVC)
+
+	require.Len(t, flips, 2, "a single segment carries both its captions")
+	require.Equal(t, "00:01:20.000", flips[0].line1)
+	require.Equal(t, "SEG 40", flips[0].line2)
+	require.Equal(t, "00:01:21.000", flips[1].line1)
+	require.Equal(t, "SEG 40", flips[1].line2)
+	require.Greater(t, flips[0].frame, 0, "the flip follows its own build, so it lags the cue boundary")
+	require.Less(t, flips[0].frame, 30)
+	require.Greater(t, flips[1].frame, 30)
 }
 
 // TestGenLiveSegmentCC608NrTimeOffset covers the case where a segment does not start at

--- a/cmd/livesim2/app/cc608_inject_test.go
+++ b/cmd/livesim2/app/cc608_inject_test.go
@@ -297,6 +297,68 @@ func TestGenLiveSegmentCC608(t *testing.T) {
 	}, flips)
 }
 
+// TestGenLiveSegmentCC608NrTimeOffset covers the case where a segment does not start at
+// segmentNr * segmentDuration. Two URL options decouple the two: startnr_ renumbers the
+// segments (nr 45 with startnr_5 is the segment at media time 80 s, not 90 s), and a
+// non-zero availabilityStartTime shifts every segment's wall clock without touching its
+// number. The caption clock must follow the segment's own media time — applyCC608 derives
+// it from the fragment's already-shifted tfdt plus cfg.StartTimeS, never from the segment
+// number — while "SEG <nr>" keeps naming the number the client asked for. Both cases below
+// carry the same media (80 s onwards), so the number moves independently of the clock.
+func TestGenLiveSegmentCC608NrTimeOffset(t *testing.T) {
+	vodFS := os.DirFS("testdata/assets")
+	am := newAssetMgr(vodFS, "", false, false)
+	logger := slog.Default()
+	require.NoError(t, am.discoverAssets(logger))
+	asset, ok := am.findAsset("testpic_2s")
+	require.True(t, ok)
+
+	cases := []struct {
+		desc       string
+		startNr    uint32
+		startTimeS int
+		nr         int
+		nowMS      int
+		want       []cc608Flip
+	}{
+		{
+			// startnr_5: media time is (nr-5)*2 s, so segment 45 is the 80 s one and the
+			// clock must read 00:01:2x, not the 00:01:3x that 45*2 s would give.
+			desc: "startnr_5", startNr: 5, nr: 45, nowMS: 100_000,
+			want: []cc608Flip{
+				{30, "00:01:21.000", "SEG 45"},
+				{60, "00:01:22.000", "SEG 46"},
+				{90, "00:01:23.000", "SEG 46"},
+			},
+		},
+		{
+			// availabilityStartTime one hour past the epoch: same media time and same
+			// numbers, every caption clock an hour later.
+			desc: "ast_3600", startTimeS: 3600, nr: 40, nowMS: 3_700_000,
+			want: []cc608Flip{
+				{30, "01:01:21.000", "SEG 40"},
+				{60, "01:01:22.000", "SEG 41"},
+				{90, "01:01:23.000", "SEG 41"},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			cfg := NewResponseConfig()
+			cfg.CC608 = &CC608Config{Channel: "CC1", Lang: "eng"}
+			cfg.StartNr = Ptr(c.startNr)
+			cfg.StartTimeS = c.startTimeS
+
+			var samples []mp4.FullSample
+			for _, n := range []int{c.nr, c.nr + 1} {
+				samples = append(samples, cc608SegSamples(t, vodFS, asset, cfg,
+					fmt.Sprintf("V300/%d.m4s", n), c.nowMS, true)...)
+			}
+			require.Equal(t, c.want, decodeSamples(t, samples, carriage.CodecAVC))
+		})
+	}
+}
+
 // TestGenLiveSegmentCC608HEVC is the HEVC counterpart of TestGenLiveSegmentCC608:
 // it drives two consecutive real hev1 segments (bbb_hevc_ac3_8s, 24 fps, 2s
 // segments) through genLiveSegment with timecc608, round-trips them through the

--- a/cmd/livesim2/app/cc608_test.go
+++ b/cmd/livesim2/app/cc608_test.go
@@ -21,8 +21,18 @@ func TestCreateCC608Config(t *testing.T) {
 		{"two-letter", "CC1-sv", &CC608Config{Channel: "CC1", Lang: "sv"}, ""},
 		{"region subtag", "CC1-en-US", &CC608Config{Channel: "CC1", Lang: "en-US"}, ""},
 		{"script subtag", "CC1-zh-Hans", &CC608Config{Channel: "CC1", Lang: "zh-Hans"}, ""},
-		{"missing hyphen", "CC1", nil, `timecc608 must be <channel>-<lang>, got "CC1"`},
-		{"empty", "", nil, `timecc608 must be <channel>-<lang>, got ""`},
+		{"self-contained", "CC1-eng-sc", &CC608Config{Channel: "CC1", Lang: "eng", SelfContained: true}, ""},
+		{"self-contained subtag lang", "CC1-en-US-sc",
+			&CC608Config{Channel: "CC1", Lang: "en-US", SelfContained: true}, ""},
+		// "sc" is only the self-contained field when something precedes it, so a lone
+		// "sc" is the Sardinian language tag.
+		{"lang sc", "CC1-sc", &CC608Config{Channel: "CC1", Lang: "sc"}, ""},
+		{"lang sc self-contained", "CC1-sc-sc", &CC608Config{Channel: "CC1", Lang: "sc", SelfContained: true}, ""},
+		// Only a literal "sc" is the self-contained field; anything else trailing is
+		// part of the language tag.
+		{"other trailing field", "CC1-eng-xx", &CC608Config{Channel: "CC1", Lang: "eng-xx"}, ""},
+		{"missing hyphen", "CC1", nil, `timecc608 must be <channel>-<lang>[-sc], got "CC1"`},
+		{"empty", "", nil, `timecc608 must be <channel>-<lang>[-sc], got ""`},
 		{"channel CC2", "CC2-eng", nil, `timecc608 channel "CC2" not supported (only CC1)`},
 		{"channel word", "SERVICE1-eng", nil, `timecc608 channel "SERVICE1" not supported (only CC1)`},
 		{"empty lang", "CC1-", nil, `timecc608 language "" is not a valid RFC-5646 code`},

--- a/cmd/livesim2/app/configurl_test.go
+++ b/cmd/livesim2/app/configurl_test.go
@@ -143,11 +143,27 @@ func TestProcessURLCfg(t *testing.T) {
 			err: "",
 		},
 		{
+			url:         "/livesim2/timecc608_CC1-eng-sc/asset.mpd",
+			nowMS:       0,
+			contentPart: "asset.mpd",
+			wantedCfg: &ResponseConfig{
+				URLParts:                     []string{"", "livesim2", "timecc608_CC1-eng-sc", "asset.mpd"},
+				URLContentIdx:                3,
+				StartTimeS:                   0,
+				TimeShiftBufferDepthS:        Ptr(defaultTimeShiftBufferDepthS),
+				StartNr:                      Ptr(uint32(0)),
+				AvailabilityTimeCompleteFlag: true,
+				TimeSubsDurMS:                defaultTimeSubsDurMS,
+				CC608:                        &CC608Config{Channel: "CC1", Lang: "eng", SelfContained: true},
+			},
+			err: "",
+		},
+		{
 			url:         "/livesim2/timecc608_CC1/asset.mpd",
 			nowMS:       0,
 			contentPart: "",
 			wantedCfg:   nil,
-			err:         `key=timecc608, err=timecc608 must be <channel>-<lang>, got "CC1"`,
+			err:         `key=timecc608, err=timecc608 must be <channel>-<lang>[-sc], got "CC1"`,
 		},
 		{
 			url:         "/livesim2/timecc608_CC2-eng/asset.mpd",

--- a/cmd/livesim2/app/handler_urlgen_test.go
+++ b/cmd/livesim2/app/handler_urlgen_test.go
@@ -102,6 +102,11 @@ func TestCreateURLCC608(t *testing.T) {
 			wantInURL: []string{"/livesim2/timecc608_CC1-eng/testpic_2s/Manifest.mpd"},
 		},
 		{
+			desc:      "self-contained CC1-eng-sc",
+			params:    map[string]string{"timecc608": "CC1-eng-sc"},
+			wantInURL: []string{"/livesim2/timecc608_CC1-eng-sc/testpic_2s/Manifest.mpd"},
+		},
+		{
 			desc:    "unsupported channel",
 			params:  map[string]string{"timecc608": "CC2-eng"},
 			wantErr: "invalid timecc608",
@@ -130,7 +135,7 @@ func TestCreateURLCC608(t *testing.T) {
 				return
 			}
 			require.Empty(t, data.Errors, "unexpected errors: %v", data.Errors)
-			require.Equal(t, "CC1-eng", data.TimeCC608)
+			require.Equal(t, c.params["timecc608"], data.TimeCC608, "the form field keeps what was entered")
 			for _, want := range c.wantInURL {
 				require.Contains(t, data.URL, want)
 			}

--- a/cmd/livesim2/app/urlgen.templ
+++ b/cmd/livesim2/app/urlgen.templ
@@ -260,7 +260,7 @@ templ urlgenPage(d urlGenData) {
 					<details>
 						<summary>Inject in-band CTA-608 captions...</summary>
 						<label for="timecc608">
-							CEA-608 channel and language as &lt;channel&gt;-&lt;lang&gt; (e.g. CC1-eng). Injected into the AVC/HEVC video as a ticking UTC clock plus segment number, and advertised with an Accessibility descriptor. Only CC1 is supported. Rejected for encrypted or already-captioned assets.
+							CEA-608 channel and language as &lt;channel&gt;-&lt;lang&gt;[-sc] (e.g. CC1-eng). Injected into the AVC/HEVC video as a ticking UTC clock plus segment number, and advertised with an Accessibility descriptor. Only CC1 is supported. Rejected for encrypted or already-captioned assets. Each caption flips on the first frame of the second it names, which makes it span the segment boundary. Append -sc (e.g. CC1-eng-sc) to keep every caption inside its own segment instead, which costs ~0.5 s of delay before each caption appears.
 							<input type="text" id="timecc608" name="timecc608" value={ d.TimeCC608 } placeholder="CC1-eng"/>
 						</label>
 					</details>

--- a/cmd/livesim2/app/urlgen_templ.go
+++ b/cmd/livesim2/app/urlgen_templ.go
@@ -843,7 +843,7 @@ func urlgenPage(d urlGenData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "> Region 1 (top)</label></fieldset></details> <details><summary>Inject in-band CTA-608 captions...</summary> <label for=\"timecc608\">CEA-608 channel and language as &lt;channel&gt;-&lt;lang&gt; (e.g. CC1-eng). Injected into the AVC/HEVC video as a ticking UTC clock plus segment number, and advertised with an Accessibility descriptor. Only CC1 is supported. Rejected for encrypted or already-captioned assets. <input type=\"text\" id=\"timecc608\" name=\"timecc608\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "> Region 1 (top)</label></fieldset></details> <details><summary>Inject in-band CTA-608 captions...</summary> <label for=\"timecc608\">CEA-608 channel and language as &lt;channel&gt;-&lt;lang&gt;[-sc] (e.g. CC1-eng). Injected into the AVC/HEVC video as a ticking UTC clock plus segment number, and advertised with an Accessibility descriptor. Only CC1 is supported. Rejected for encrypted or already-captioned assets. Each caption flips on the first frame of the second it names, which makes it span the segment boundary. Append -sc (e.g. CC1-eng-sc) to keep every caption inside its own segment instead, which costs ~0.5 s of delay before each caption appears. <input type=\"text\" id=\"timecc608\" name=\"timecc608\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Fixes #325.

## What & why

A pop-on CTA-608 caption is two transmissions: a **build** (RCL + ENM + rows) written into non-displayed memory,
and an **EOC** that flips it on screen. Both drain at one 608 pair per frame, so where the build sits decides when
the caption appears.

`generate.BuildUnitCues` starts the build at its own cue's first frame and lets the EOC follow, so — as its own
comment notes — the flip lands at `start+pairs`. For the two-row clock cue (~16-19 pairs) that is **0.6-0.75 s
into the very second the caption names**, and the caption then straddles the boundary into the next cue. The
timestamp and segment number visibly lagged the picture.

This places each cue's **EOC on its cue's first frame** and transmits the build over the frames immediately
before it, so the flip coincides with the cue boundary and a caption is displayed over exactly the interval its
text names.

That accuracy costs self-contained segments, which is a genuine trade rather than a strict improvement, so the
previous behaviour stays reachable per stream: **`timecc608_CC1-eng-sc`** keeps every caption inside the segment
that carries it. The default is the fix; `-sc` is the opt-out. See
[Opting out](#opting-out-timecc608_cc1-eng-sc) below.

## How

`cc608UnitFrames` drives go-608's `schedule.Scheduler` directly instead of calling `BuildUnitCues`. The
scheduler's FIFO is gated by eligibility time, so pushing build-then-EOC keeps the 608 byte stream ordered and
lands the flip on the intended frame. Everything used is already exported by go-608 v0.6.0 — no dependency bump.

Two consequences, both deliberate:

- **Captions span unit boundaries.** A fragment carries the build for the first cue of whatever follows it — the
  next fragment, or the next segment for a final fragment — which is why the next unit's segment number is now
  passed down through `injectCC608`. A client that starts, seeks, or joins mid-stream receives a leading EOC
  without the build that belongs to it, and what it shows for that cue period depends on its decoder: a fresh 608
  decoder has nothing loaded and shows **no caption**, while one that keeps 608 state across the discontinuity
  flips whatever was last preloaded and can show **one cue of a stale caption**. Either way it corrects at the next
  cue boundary, typically within a second. Within this mode the server cannot avoid it — any pair sent ahead of
  the EOC to clear the state would erase the build about to be flipped — which is why the behaviour is selectable
  rather than simply replaced: a client that needs segment-independent captions asks for `-sc`. This is a real
  change for seeking clients, and it is the argument for the open question in #325 about skipping a segment's
  first cue instead of flipping it.
- **Each cue is encoded with a fresh `cta608.Encoder`** (in both modes), so a build always fully describes its
  screen. This is what lets independently generated, on-demand segments line up: the build in segment N's tail and
  the flip at segment N+1's first frame come from separate requests and must agree without shared encoder state.
  It is also what lets a receiver joining mid-unit get a whole caption rather than one row of one.

A build that cannot fit between the previous flip and its own is now an explicit error rather than a silently
dropped build (which would leave an EOC with nothing loaded, i.e. a caption that never appears).

The 608 data rate is unchanged at one pair per frame, so `cc_count` stays `round(600/fps)` and the stream remains
in line with the A/53 / SCTE-128 rate model. The alternative — bursting a whole cue into the cue's first frame —
was rejected for that reason, and because consumers that trust parser-reported cue times would mistime it: the
SVTA `@svta/cml-608` parser (the dash.js/hls.js decoder) advances its internal clock ~33.4 ms per byte pair
within one `addData` call, so a ~19-pair burst reads as ~0.6 s late.

The README's `timecc608` description now covers where a cue's build and flip sit and what that costs at a
discontinuity; the CHANGELOG entry is a short summary pointing there.

## Opting out: `timecc608_CC1-eng-sc`

Because the mid-stream-join cost above is a real trade rather than a strict improvement, the previous behaviour is
kept available per stream. The `timecc608` grammar becomes `<channel>-<lang>[-sc]`:

- `timecc608_CC1-eng` (default) — flip on the cue's first frame. Frame-accurate; captions span the segment boundary.
- `timecc608_CC1-eng-sc` — self-contained: a cue's build **and** its flip ride the cue's own frames, so every
  segment is independently decodable and a client starting, seeking or joining anywhere sees a whole caption at
  once. The cost is that each caption appears ~0.5 s into the second its clock names (measured: flips at frames 15
  and 45 for cue boundaries 0 and 30 at 30 fps).

A trailing `sc` counts as the flag only when a language precedes it, so a hyphenated language tag still parses:
`CC1-sc` is the Sardinian tag, `CC1-sc-sc` is that language self-contained, `CC1-en-US-sc` works, and `CC1-eng-xx`
stays the language `eng-xx`. Only a tag whose final subtag is literally `sc` cannot be expressed.

`cc608UnitFrames` takes a `cc608FlipMode` and keeps the fresh-encoder-per-cue rebuild in **both** modes, rather
than delegating the two behaviours to go-608 v0.7.0's `generate.BuildUnitCues` with and without
`WithFlipAtCueStart`. `BuildUnitCues` shares one `cta608.Encoder` across a unit's cues, so cues after the first are
transmitted as diffs; a receiver joining mid-unit would then flip a diff and see one row of a two-row caption — and
no test would catch it, since a decoder that saw cue 0 applies the diff correctly. Adopting the upstream helper
remains possible, just not without giving up that property.

`/urlgen` documents the option and its trade-off. The field itself needed no change: it is free text validated
through `CreateCC608Config`.

## Testing

`go test ./...` and `golangci-lint` are green. The caption tests now decode **two consecutive units as one
stream**, which is the only way to observe the cross-boundary build:

- `TestInjectCC608AVC` / `HEVC` — flips land on frames 30, 60, 90 of the two-unit stream, and the frame-60 flip
  (unit B's first cue, built in unit A's tail) carries unit B's segment number.
- `TestGenLiveSegmentCC608` — two real `testpic_2s/V300` segments through `genLiveSegment` plus an encode
  round-trip: `00:01:21.000/SEG 40`, `00:01:22.000/SEG 41`, `00:01:23.000/SEG 41`.
- `TestGenLiveSegmentCC608HEVC` — same for `bbb_hevc_ac3_8s` at 24 fps (frames 24/48/72).
- `TestGenLiveSegmentCC608_2997fps` — two 2.002 s segments at 30000/1001: `00:01:21.081`, `00:01:22.082`,
  `00:01:23.083`, so the boundary cue is frame-accurate where a fractional frame duration would otherwise drift.
- `TestGenLiveSegmentCC608NrTimeOffset` — the caption clock follows the segment's media time, not
  `segmentNr * segmentDuration`: with `startnr_5` segment 45 is the 80 s segment and reads
  `00:01:21.000/SEG 45`, and with `availabilityStartTime` an hour past the epoch the same media and numbers read
  `01:01:21.000/SEG 40`. Deriving the clock from `meta.newNr * meta.newDur` instead fails only this test, at
  `00:01:31.000`.
- `TestInjectCC608FirstCueUnbuilt` — pins the mid-stream-join behaviour described above.
- `TestCC608UnitFramesBuildDoesNotFit` — the new misfit error.
- `TestInjectCC608SelfContained` / `TestGenLiveSegmentCC608SelfContainedSegment` — in `-sc` mode a **single** unit
  shows both of its cues (the direct contrast with `TestInjectCC608FirstCueUnbuilt`, where the same unit shows only
  its second), each flip landing inside the cue it names. The second test goes through `genLiveSegment`, so the
  `CC608Config.SelfContained` -> `applyCC608` plumbing is covered.
- `TestCC608UnitFramesSelfContainedDoesNotFit` — the self-contained misfit error.
- `TestCreateCC608Config` / `TestProcessURLCfg` / `TestCreateURLCC608` — the `[-sc]` grammar, including the
  Sardinian-tag cases, the URL -> config wiring, and the wizard emitting `timecc608_CC1-eng-sc`.

## Related

The same scheduling change is wanted in Eyevinn/moqlivemock (Eyevinn/moqlivemock#118), which shares this
scheduler, and the logic could later move into go-608 itself (Eyevinn/go-608#55) so both consumers share one
implementation. It was surfaced by player-side caption work where a low-latency player cannot recover a caption
transmitted after the moment it should be displayed.



