### PR TITLE
chore(deps): bump mp4ff to v0.55.0 and go-608 to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Changed
+
+- mp4ff dependency bumped to v0.55.0 and go-608 to v0.7.0
 
 ## [1.12.0] - 2026-07-23
 

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.25.0
 require (
 	github.com/Comcast/gots/v2 v2.3.0
 	github.com/Eyevinn/dash-mpd v0.16.0
-	github.com/Eyevinn/go-608 v0.6.0
+	github.com/Eyevinn/go-608 v0.7.0
 	github.com/Eyevinn/hi264 v0.10.0
-	github.com/Eyevinn/mp4ff v0.54.0
+	github.com/Eyevinn/mp4ff v0.55.0
 	github.com/a-h/templ v0.3.1020
 	github.com/beevik/etree v1.7.0
 	github.com/caddyserver/certmagic v0.25.4

--- a/go.sum
+++ b/go.sum
@@ -9,12 +9,12 @@ github.com/Comcast/gots/v2 v2.3.0 h1:UQ5zx90hTYg6cuyLPFwrts0J+MSpxDnjIrAtPi4zkVg
 github.com/Comcast/gots/v2 v2.3.0/go.mod h1:firJ11on3eUiGHAhbY5cZNqG0OqhQ1+nSZHfsEEzVVU=
 github.com/Eyevinn/dash-mpd v0.16.0 h1:5HgrL/vOgT2cSop6jVucwc3RsyReKw1M/ME/20r1eFU=
 github.com/Eyevinn/dash-mpd v0.16.0/go.mod h1:mh/BF4gvesMIYxlNHJMI+H9FLsJYeud9yqGibxcgGpE=
-github.com/Eyevinn/go-608 v0.6.0 h1:4SYnjjW94+OQkARD5q45HCS7nvLpIP8YVx0tx79ucNo=
-github.com/Eyevinn/go-608 v0.6.0/go.mod h1:nHxTZQC/V47EJaFci5Vh+CCsEuo4NF7qt/mmvWyE0AI=
+github.com/Eyevinn/go-608 v0.7.0 h1:vrSvMFjRUb8GPgLc/cPhsiEQQcjPGHIHEwqJI+mFWuY=
+github.com/Eyevinn/go-608 v0.7.0/go.mod h1:Rs0dVVIrIgSaFYYV0QfeZOXlYgkr0XV9ri0bA63j4pA=
 github.com/Eyevinn/hi264 v0.10.0 h1:4CgeRcBT8Y03BuHHr9u7ErMN5Iiw1mGbvKNU9s4QFPg=
 github.com/Eyevinn/hi264 v0.10.0/go.mod h1:ag1j/wxUs7EvZu6qEZBRyLJ0bJW4OUjO8ip8c2TfLTQ=
-github.com/Eyevinn/mp4ff v0.54.0 h1:WSkbWQbvlB1jAuTfUlqjhqdp3nkH+oe7Ht6hzDCWx+g=
-github.com/Eyevinn/mp4ff v0.54.0/go.mod h1:AhC+bOI7GSZmzuN4zFY9U76qMedbHI+8BdQXWrC9+8U=
+github.com/Eyevinn/mp4ff v0.55.0 h1:wFShr5eqcJaVd15/uPMe747sAWPbz7dl2TfhusDx+Kk=
+github.com/Eyevinn/mp4ff v0.55.0/go.mod h1:AhC+bOI7GSZmzuN4zFY9U76qMedbHI+8BdQXWrC9+8U=
 github.com/a-h/templ v0.3.1020 h1:ypAT/L5ySWEnZ6Zft/5yfoWXYYkhFNvEFOeeqecg4tw=
 github.com/a-h/templ v0.3.1020/go.mod h1:A2DlK61v+K+NRoGnhmYbNYVmtYHcFO5/AisMvBdDxTM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
Dependency-only bump, no livesim2 code changes.

## mp4ff v0.54.0 -> v0.55.0

Adds AV1 metadata OBUs with CTA-608 caption carriage, `avc.CreateSEINalu`/`hevc.CreateSEINalu`, `sei.CreateCTA608SEIMessage`, tkhd transformation-matrix preservation, Motion JPEG sample entries and `dec3` JOC (Atmos) detection. Fixes several panics on truncated/short SEI NAL units and avcC trailing-byte handling.

Upstream renames CEA-608 to CTA-608 in the `sei` package (`sei.ParseCEA608` -> `sei.ParseCTA608` etc.) with no aliases, which is a breaking change. livesim2 does not import `mp4ff/sei` directly, so nothing here needs adapting.

## go-608 v0.6.0 -> v0.7.0

- Fixes [Eyevinn/go-608#54](https://github.com/Eyevinn/go-608/issues/54): caption payloads are now assigned in presentation order instead of decode order. That bug lived in `internal/mp4io`, which only go-608 own CLIs use; livesim2 does its own presentation-order mapping in `injectCC608`, so the served captions were already correct and are unchanged by this bump.
- `carriage` now delegates the SEI wire format to mp4ff, with output verified byte-identical and pinned by a golden test upstream. `carriage` public API is unchanged.
- New upstream API that livesim2 currently duplicates locally and could adopt in a follow-up: `carriage.SpliceSEIBeforeVCL` (vs. the local `spliceSEIBeforeVCL`/`isVCLNalu`) and `generate.WithFlipAtCueStart` (vs. the cue-boundary flip logic in #326).
- Also adds AV1 (`av01`) CTA-608 carriage, which livesim2 does not use yet since `cc608CodecFor` accepts only AVC and HEVC.

## Verification

- `go build ./...`, `go vet ./...` clean
- `go test ./...` all green, including the CTA-608 injection tests that decode the injected SEI back on real B-frame content
- `golangci-lint run`: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)