### PR TITLE
Release v1.13.0: timecc608 caption modes, paint-on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [1.13.0] - 2026-08-11
+
 ### Added
 
 - Optional mode field on `timecc608`, whose value is now `<channel>-<lang>[-<mode>[-<modifier>]]`, choosing
@@ -523,7 +527,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - features and URLs listed at livesim2 root page
 - configurable generated stpp subtitles with timing info
 
-[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/Dash-Industry-Forum/livesim2/compare/v1.9.0...v1.10.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	commitVersion string = "v1.12.0"    // Should be updated during build
-	commitDate    string = "1784757600" // commitDate in Epoch seconds (can be filled/updated in during build)
+	commitVersion string = "v1.13.0"    // Should be updated during build
+	commitDate    string = "1786399200" // commitDate in Epoch seconds (can be filled/updated in during build)
 )
 
 // GetVersion - get version, commitHash and  commitDate depending on what is inserted


### PR DESCRIPTION
Release v1.13.0. The theme is in-band CTA-608 caption modes: `timecc608` gains a mode
field and now defaults to paint-on, so a segment's captions no longer depend on its
neighbours. Also bumps mp4ff to v0.55.0 and go-608 to v0.9.0.

Option syntax is now `timecc608_<channel>-<lang>[-<mode>[-<modifier>]]`, e.g.
`timecc608_CC1-eng`, `timecc608_CC1-eng-pop`, `timecc608_CC1-swe-roll3`.

### Added

- Optional mode field on `timecc608`, whose value is now `<channel>-<lang>[-<mode>[-<modifier>]]`, choosing
  the CTA-608 caption mode: `paint` (the default), `pop`, `pop-sc`, `roll2` or `roll3`. Paint-on and roll-up
  type the caption out two characters per frame — paint-on onto a screen cleared at the start of each
  second, roll-up onto the base row of a 2- or 3-row window that scrolls the earlier lines up — and both
  keep every caption inside the segment that carries it, so segments stay independently decodable for a
  client that starts, seeks or joins mid-stream. Roll-up is limited to 2 or 3 rows because the caption's own
  lines put its base row at row 3. Generated by go-608 v0.9.0's `generate.BuildUnitPaintCues` and
  `BuildUnitRollUpCues`.

### Changed

- `timecc608` defaults to paint-on instead of pop-on, so by default no segment's captions depend on its
  neighbours. Pop-on remains available as `-pop`, with `-pop-sc` for the self-contained placement; a bare
  `-sc` (which used to ask for that) is rejected with a message pointing at `-pop-sc`.
- The `timecc608` language must be a three-letter ISO 639-2 code (`eng`, `swe`), the form the SCTE 214-1
  CEA-608 accessibility descriptor value is defined in, and the only place this option's language is used.
  RFC 5646 tags that DASH's `@lang` accepts — `en`, `en-US`, `zh-Hans` — were previously allowed through
  into `value="CC1=..."` and are now rejected. With the language a single field, an unknown mode or
  modifier is reported instead of being read as part of it.
- mp4ff dependency bumped to v0.55.0 and go-608 to v0.9.0
- The CTA-608 cue scheduling for `timecc608` is back to go-608's per-unit builders, whose v0.8.0
  `generate.Unit` (number, start time and frame count as independent inputs) and `WithFlipAtCueStart`
  cover both pop-on flip placements livesim2 needs, so the local copy of that scheduler is gone. Same
  bytes on the wire.
- A `timecc608` caption cue is never shorter than a second now that go-608 v0.9.0 divides a segment down
  into whole periods: a segment whose duration is not a multiple of a second, e.g. 1.92 s, gets one cue
  covering it instead of two shorter ones. Segments of 2 s and 2.002 s are unaffected.

### Fixed

- In-band CTA-608 captions in pop-on mode (`timecc608_CC1-eng-pop`) are now displayed over exactly the
  interval their text names, instead of appearing 0.6-0.75 s into it. Each cue's flip rides its cue's first
  frame, with the build sent over the preceding frames. Such captions consequently span segment boundaries,
  which costs a client that starts or seeks mid-stream its first cue period — see the
  [README](README.md). The new default mode, paint-on, has neither problem.

### Incompatible changes

Both affect `timecc608` URLs only:

- The default mode changed from pop-on to paint-on. Existing `timecc608_CC1-eng` URLs keep working but
  render differently; add `-pop` to keep the old behaviour.
- Two-letter and subtagged languages (`en`, `en-US`) are rejected — use ISO 639-2 (`eng`). A bare `-sc`
  modifier is rejected in favour of `-pop-sc`.

### Release bookkeeping

- `internal/version.go`: `v1.12.0` → `v1.13.0`, `commitDate` → 2026-08-11
- `CHANGELOG.md`: `Unreleased` entries moved to `[1.13.0] - 2026-08-11`, `Unreleased` reset, compare links updated

### Verification

`go build ./...` clean, `go test ./...` passing, `golangci-lint run` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
