### PR TITLE
fix(scte35): set the splice time on the section so pts_adjustment is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   presentation time at all. Opt-in, since a player acting on both it and the existing callback beacons
   reports each timeline point twice.
 
+### Fixed
+
+- The SCTE-35 messages generated for the `scte35_` URL option carried `pts_adjustment = 2^33 - pts_time`
+  instead of zero, so the splice time a receiver computes as `(pts_time + pts_adjustment) mod 2^33` was
+  always 0. The intended time was only visible in the `emsg` header. The splice time is now set on the
+  `splice_info_section` rather than on the `splice_insert()` command, which is what gots derives
+  `pts_adjustment` from, and a regression test decodes the generated payload to check both fields.
+
 ### Changed
 
 - The ad-break schedule (fixed or periodic breaks, the break instances signaled in an MPD, and the AD BREAK

--- a/pkg/scte35/scte35.go
+++ b/pkg/scte35/scte35.go
@@ -117,9 +117,14 @@ func CreateSpliceInsertPayload(p SpliceInsertParams) []byte {
 		cmd.SetIsAutoReturn(p.AutoReturn)
 	}
 	cmd.SetHasPTS(true)
-	cmd.SetPTS(gots.PTS(p.PtsTime))
 	cmd.SetIsOut(p.OutOfNetworkIndicator)
 	cmd.SetSpliceImmediate(p.SpliceImmediateFlag)
 	s.SetCommandInfo(cmd)
+	// Set the splice time on the section, not on the command: gots encodes
+	// pts_adjustment as the difference between the two (modify.go UpdateData), so
+	// setting only the command time yields pts_adjustment = 2^33 - pts_time, and a
+	// receiver adding them modulo 2^33 gets a splice time of 0. Setting it here sets
+	// both and leaves pts_adjustment at 0.
+	s.SetPTS(gots.PTS(p.PtsTime))
 	return s.UpdateData()
 }

--- a/pkg/scte35/scte35_test.go
+++ b/pkg/scte35/scte35_test.go
@@ -3,6 +3,7 @@ package scte35_test
 import (
 	"testing"
 
+	gotsscte35 "github.com/Comcast/gots/v2/scte35"
 	"github.com/Dash-Industry-Forum/livesim2/pkg/scte35"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,6 +67,57 @@ func TestSCTE35Generation(t *testing.T) {
 		if emsg != nil {
 			assert.Equal(t, int(tc.timescale), int(emsg.TimeScale), "emsg timescale")
 			assert.Equal(t, int(tc.wantedPTS), int(emsg.PresentationTime), "emsg PTS")
+			// The splice time in the payload must agree with the emsg header, i.e. be the
+			// same instant expressed on the 90kHz SCTE-35 clock.
+			sis := decodeSpliceInfoSection(t, emsg.MessageData)
+			assert.Equal(t, 0, int(ptsAdjustment(t, emsg.MessageData)), "pts_adjustment")
+			wantPTS90 := tc.wantedPTS * 90000 / tc.timescale
+			assert.Equal(t, int(wantPTS90), int(sis.PTS()), "splice time in payload")
 		}
 	}
+}
+
+// TestSpliceInsertPayloadSpliceTime guards the pts_adjustment encoding. gots derives
+// pts_adjustment from the difference between the section time and the command time, so
+// setting only the latter produces pts_adjustment = 2^33 - pts_time and every receiver
+// adding the two modulo 2^33 sees a splice time of 0.
+func TestSpliceInsertPayloadSpliceTime(t *testing.T) {
+	const ptsTime = 900_000 // 10s on the 90kHz clock
+	const duration = 20 * 90_000
+	payload := scte35.CreateSpliceInsertPayload(scte35.SpliceInsertParams{
+		PtsTime:               ptsTime,
+		Duration:              duration,
+		SpliceEventID:         42,
+		Tier:                  4095,
+		OutOfNetworkIndicator: true,
+		AutoReturn:            true,
+	})
+
+	assert.Equal(t, uint64(0), ptsAdjustment(t, payload), "pts_adjustment must be zero")
+
+	sis := decodeSpliceInfoSection(t, payload)
+	assert.Equal(t, gotsscte35.SpliceCommandType(gotsscte35.SpliceInsert), sis.Command(), "splice command type")
+	assert.Equal(t, uint64(ptsTime), uint64(sis.PTS()), "splice time after pts_adjustment")
+	cmd, ok := sis.CommandInfo().(gotsscte35.SpliceInsertCommand)
+	require.True(t, ok, "splice_insert command")
+	assert.Equal(t, uint32(42), cmd.EventID(), "splice_event_id")
+	assert.True(t, cmd.IsOut(), "out_of_network_indicator")
+	assert.Equal(t, uint64(duration), uint64(cmd.Duration()), "break_duration")
+}
+
+// ptsAdjustment reads the 33-bit pts_adjustment field out of a splice_info_section.
+func ptsAdjustment(t *testing.T, sis []byte) uint64 {
+	t.Helper()
+	require.Greater(t, len(sis), 9, "splice_info_section too short")
+	return uint64(sis[4]&0x01)<<32 | uint64(sis[5])<<24 | uint64(sis[6])<<16 |
+		uint64(sis[7])<<8 | uint64(sis[8])
+}
+
+// decodeSpliceInfoSection parses a raw splice_info_section (as carried in an emsg).
+// gots' parser expects an MPEG-2 section with a leading pointer_field, so one is added.
+func decodeSpliceInfoSection(t *testing.T, sis []byte) gotsscte35.SCTE35 {
+	t.Helper()
+	parsed, err := gotsscte35.NewSCTE35(append([]byte{0x00}, sis...))
+	require.NoError(t, err, "decode splice_info_section")
+	return parsed
 }


### PR DESCRIPTION
## The bug

`CreateSpliceInsertPayload` set the splice time on the `splice_insert()` command only:

```go
cmd.SetPTS(gots.PTS(p.PtsTime))
```

gots encodes `pts_adjustment` as the difference between the **section** time and the **command**
time (`scte35/modify.go`, `UpdateData`):

```go
ptsAdj := subtractPTS(s.pts, s.commandInfo.PTS())
```

With `s.pts` never set, that is `2^33 − pts_time`. SCTE-35 defines the effective splice time as
`(pts_time + pts_adjustment) mod 2^33`, so **every SCTE-35 message livesim2 has emitted resolves to
splice time 0**. For `scte35_1` on a 90 kHz timeline:

```
pts_time:        900000
pts_adjustment: 8589034592
→ (900000 + 8589034592) mod 2^33 = 0
```

The intended time survived only in the `emsg` header (`presentation_time`), which the existing unit
test checks — which is why this went unnoticed. Anything reading the SCTE-35 payload itself, as
SCTE 214-1 §6.7.3 and every SCTE-35 parser do, sees 0. Confirmed by decoding a generated payload
with an independent implementation (`github.com/Comcast/scte35-go`).

## The fix

Call `SCTE35.SetPTS` on the section after `SetCommandInfo`. It sets the section time *and* the
command time, so `pts_adjustment` comes out as 0.

## Test

The test now decodes the generated `splice_info_section` and asserts both the raw `pts_adjustment`
field and the resulting splice time — for the payload on its own, and for the one inside each
`emsg` the table-driven test already generates, where the splice time must agree with the `emsg`
header expressed on the 90 kHz clock. Both new assertions fail on `main` and pass here.

No new dependencies: gots' own parser is used for the decode (with a `pointer_field` byte prefixed,
which it expects and a raw section carried in an `emsg` does not have).

`go test ./...` green, `golangci-lint run` clean.

This is a prerequisite for the wider rework of the `scte35_` option (a proper option grammar,
`time_signal` with segmentation descriptors, and MPD `EventStream` carriage), which builds on these
messages — see also #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
